### PR TITLE
Add Paris 8 photobooth page and navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import Paris4Page from './components/Paris4Page';
 import Paris5Page from './components/Paris5Page';
 import Paris6Page from './components/Paris6Page';
 import Paris7Page from './components/Paris7Page';
+import Paris8Page from './components/Paris8Page';
 import { 
   Camera,
   Sparkles,
@@ -49,6 +50,7 @@ function App() {
   const [showParis5Page, setShowParis5Page] = useState(false);
   const [showParis6Page, setShowParis6Page] = useState(false);
   const [showParis7Page, setShowParis7Page] = useState(false);
+  const [showParis8Page, setShowParis8Page] = useState(false);
   const [previousPage, setPreviousPage] = useState<string>('home');
 
   // Fonction pour remettre le scroll en haut
@@ -59,7 +61,7 @@ function App() {
   // Effet pour remettre le scroll en haut quand on change de page
   useEffect(() => {
     scrollToTop();
-  }, [showQuotePage, showPhotoboothDetails, showAIAnimations, showDemoRequest, showSEOPage, showPhotographerAI, showParis1Page, showParis2Page, showParis3Page, showParis4Page, showParis5Page, showParis6Page, showParis7Page]);
+  }, [showQuotePage, showPhotoboothDetails, showAIAnimations, showDemoRequest, showSEOPage, showPhotographerAI, showParis1Page, showParis2Page, showParis3Page, showParis4Page, showParis5Page, showParis6Page, showParis7Page, showParis8Page]);
 
   // Fonction pour gérer le retour depuis la page de devis
   const handleQuotePageBack = () => {
@@ -92,6 +94,9 @@ function App() {
         break;
       case 'paris7':
         setShowParis7Page(true);
+        break;
+      case 'paris8':
+        setShowParis8Page(true);
         break;
       default:
         // Rester sur la page principale
@@ -140,6 +145,10 @@ function App() {
         setShowQuotePage(false);
         setShowParis7Page(true);
       }}
+      onParis8Page={() => {
+        setShowQuotePage(false);
+        setShowParis8Page(true);
+      }}
     />;
   }
 
@@ -181,6 +190,10 @@ function App() {
       onParis7Page={() => {
         setShowPhotoboothDetails(false);
         setShowParis7Page(true);
+      }}
+      onParis8Page={() => {
+        setShowPhotoboothDetails(false);
+        setShowParis8Page(true);
       }}
       onQuoteRequest={() => {
         setShowPhotoboothDetails(false);
@@ -232,6 +245,10 @@ function App() {
         setShowAIAnimations(false);
         setShowParis7Page(true);
       }}
+      onParis8Page={() => {
+        setShowAIAnimations(false);
+        setShowParis8Page(true);
+      }}
       onQuoteRequest={() => {
         setShowAIAnimations(false);
         openQuotePage('aiAnimations');
@@ -273,6 +290,10 @@ function App() {
       onParis7Page={() => {
         setShowDemoRequest(false);
         setShowParis7Page(true);
+      }}
+      onParis8Page={() => {
+        setShowDemoRequest(false);
+        setShowParis8Page(true);
       }}
       onQuoteRequest={() => {
         setShowDemoRequest(false);
@@ -324,6 +345,10 @@ function App() {
         setShowSEOPage(false);
         setShowParis7Page(true);
       }}
+      onParis8Page={() => {
+        setShowSEOPage(false);
+        setShowParis8Page(true);
+      }}
     />;
   }
 
@@ -374,6 +399,10 @@ function App() {
         setShowPhotographerAI(false);
         setShowParis7Page(true);
       }}
+      onParis8Page={() => {
+        setShowPhotographerAI(false);
+        setShowParis8Page(true);
+      }}
     />;
   }
 
@@ -419,6 +448,10 @@ function App() {
       onParis7Page={() => {
         setShowParis1Page(false);
         setShowParis7Page(true);
+      }}
+      onParis8Page={() => {
+        setShowParis1Page(false);
+        setShowParis8Page(true);
       }}
     />;
   }
@@ -466,6 +499,10 @@ function App() {
         setShowParis2Page(false);
         setShowParis7Page(true);
       }}
+      onParis8Page={() => {
+        setShowParis2Page(false);
+        setShowParis8Page(true);
+      }}
     />;
   }
 
@@ -511,6 +548,10 @@ function App() {
       onParis7Page={() => {
         setShowParis3Page(false);
         setShowParis7Page(true);
+      }}
+      onParis8Page={() => {
+        setShowParis3Page(false);
+        setShowParis8Page(true);
       }}
     />;
   }
@@ -558,6 +599,10 @@ function App() {
         setShowParis4Page(false);
         setShowParis7Page(true);
       }}
+      onParis8Page={() => {
+        setShowParis4Page(false);
+        setShowParis8Page(true);
+      }}
     />;
   }
 
@@ -603,6 +648,10 @@ function App() {
       onParis7Page={() => {
         setShowParis5Page(false);
         setShowParis7Page(true);
+      }}
+      onParis8Page={() => {
+        setShowParis5Page(false);
+        setShowParis8Page(true);
       }}
     />;
   }
@@ -650,12 +699,16 @@ function App() {
         setShowParis6Page(false);
         setShowParis7Page(true);
       }}
+      onParis8Page={() => {
+        setShowParis6Page(false);
+        setShowParis8Page(true);
+      }}
     />;
   }
 
   if (showParis7Page) {
-    return <Paris7Page 
-      onBack={() => setShowParis7Page(false)} 
+    return <Paris7Page
+      onBack={() => setShowParis7Page(false)}
       onQuoteRequest={() => {
         setShowParis7Page(false);
         openQuotePage('paris7');
@@ -695,6 +748,60 @@ function App() {
       onParis6Page={() => {
         setShowParis7Page(false);
         setShowParis6Page(true);
+      }}
+      onParis8Page={() => {
+        setShowParis7Page(false);
+        setShowParis8Page(true);
+      }}
+    />;
+  }
+
+  if (showParis8Page) {
+    return <Paris8Page
+      onBack={() => setShowParis8Page(false)}
+      onQuoteRequest={() => {
+        setShowParis8Page(false);
+        openQuotePage('paris8');
+      }}
+      onPhotoboothDetails={() => {
+        setShowParis8Page(false);
+        setShowPhotoboothDetails(true);
+      }}
+      onAIAnimations={() => {
+        setShowParis8Page(false);
+        setShowAIAnimations(true);
+      }}
+      onSEOPage={() => {
+        setShowParis8Page(false);
+        setShowSEOPage(true);
+      }}
+      onParis1Page={() => {
+        setShowParis8Page(false);
+        setShowParis1Page(true);
+      }}
+      onParis2Page={() => {
+        setShowParis8Page(false);
+        setShowParis2Page(true);
+      }}
+      onParis3Page={() => {
+        setShowParis8Page(false);
+        setShowParis3Page(true);
+      }}
+      onParis4Page={() => {
+        setShowParis8Page(false);
+        setShowParis4Page(true);
+      }}
+      onParis5Page={() => {
+        setShowParis8Page(false);
+        setShowParis5Page(true);
+      }}
+      onParis6Page={() => {
+        setShowParis8Page(false);
+        setShowParis6Page(true);
+      }}
+      onParis7Page={() => {
+        setShowParis8Page(false);
+        setShowParis7Page(true);
       }}
     />;
   }
@@ -1505,11 +1612,17 @@ function App() {
                 >
                   Location photobooth Paris 6
                 </button>
-                <button 
+                <button
                   onClick={() => setShowParis7Page(true)}
                   className="block text-gray-600 hover:text-yellow-500 transition-colors text-left"
                 >
                   Location photobooth Paris 7
+                </button>
+                <button
+                  onClick={() => setShowParis8Page(true)}
+                  className="block text-gray-600 hover:text-yellow-500 transition-colors text-left"
+                >
+                  Location photobooth Paris 8
                 </button>
               </div>
             </div>

--- a/src/components/AIAnimationsPage.tsx
+++ b/src/components/AIAnimationsPage.tsx
@@ -35,10 +35,11 @@ interface AIAnimationsPageProps {
   onParis5Page?: () => void;
   onParis6Page?: () => void;
   onParis7Page?: () => void;
+  onParis8Page?: () => void;
   onQuoteRequest?: () => void;
 }
 
-const AIAnimationsPage: React.FC<AIAnimationsPageProps> = ({ onBack, onDemoRequest, onPhotoboothDetails, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onQuoteRequest }) => {
+const AIAnimationsPage: React.FC<AIAnimationsPageProps> = ({ onBack, onDemoRequest, onPhotoboothDetails, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onQuoteRequest }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -563,6 +564,7 @@ const AIAnimationsPage: React.FC<AIAnimationsPageProps> = ({ onBack, onDemoReque
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>

--- a/src/components/DemoRequestPage.tsx
+++ b/src/components/DemoRequestPage.tsx
@@ -27,10 +27,11 @@ interface DemoRequestPageProps {
   onParis5Page?: () => void;
   onParis6Page?: () => void;
   onParis7Page?: () => void;
+  onParis8Page?: () => void;
   onQuoteRequest?: () => void;
 }
 
-const DemoRequestPage: React.FC<DemoRequestPageProps> = ({ onBack, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onQuoteRequest }) => {
+const DemoRequestPage: React.FC<DemoRequestPageProps> = ({ onBack, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onQuoteRequest }) => {
   const [currentStep, setCurrentStep] = useState(1);
   const [formData, setFormData] = useState({
     demoType: '', // 'live' or 'video'
@@ -473,6 +474,7 @@ const DemoRequestPage: React.FC<DemoRequestPageProps> = ({ onBack, onSEOPage, on
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>

--- a/src/components/Paris1Page.tsx
+++ b/src/components/Paris1Page.tsx
@@ -25,9 +25,10 @@ interface Paris1PageProps {
   onParis5Page?: () => void;
   onParis6Page?: () => void;
   onParis7Page?: () => void;
+  onParis8Page?: () => void;
 }
 
-const Paris1Page: React.FC<Paris1PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page }) => {
+const Paris1Page: React.FC<Paris1PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -326,6 +327,7 @@ const Paris1Page: React.FC<Paris1PageProps> = ({ onBack, onQuoteRequest, onPhoto
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>

--- a/src/components/Paris2Page.tsx
+++ b/src/components/Paris2Page.tsx
@@ -22,9 +22,10 @@ interface Paris2PageProps {
   onParis5Page?: () => void;
   onParis6Page?: () => void;
   onParis7Page?: () => void;
+  onParis8Page?: () => void;
 }
 
-const Paris2Page: React.FC<Paris2PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page }) => {
+const Paris2Page: React.FC<Paris2PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -283,6 +284,7 @@ const Paris2Page: React.FC<Paris2PageProps> = ({ onBack, onQuoteRequest, onPhoto
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>

--- a/src/components/Paris4Page.tsx
+++ b/src/components/Paris4Page.tsx
@@ -25,9 +25,10 @@ interface Paris4PageProps {
   onParis5Page?: () => void;
   onParis6Page?: () => void;
   onParis7Page?: () => void;
+  onParis8Page?: () => void;
 }
 
-const Paris4Page: React.FC<Paris4PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis5Page, onParis6Page, onParis7Page }) => {
+const Paris4Page: React.FC<Paris4PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -273,6 +274,7 @@ const Paris4Page: React.FC<Paris4PageProps> = ({ onBack, onQuoteRequest, onPhoto
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>

--- a/src/components/Paris5Page.tsx
+++ b/src/components/Paris5Page.tsx
@@ -26,9 +26,10 @@ interface Paris5PageProps {
   onParis4Page?: () => void;
   onParis6Page?: () => void;
   onParis7Page?: () => void;
+  onParis8Page?: () => void;
 }
 
-const Paris5Page: React.FC<Paris5PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis6Page, onParis7Page }) => {
+const Paris5Page: React.FC<Paris5PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis6Page, onParis7Page, onParis8Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -265,6 +266,7 @@ const Paris5Page: React.FC<Paris5PageProps> = ({ onBack, onQuoteRequest, onPhoto
           { label: 'Location photobooth Paris 5', onClick: onBack },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>

--- a/src/components/Paris6Page.tsx
+++ b/src/components/Paris6Page.tsx
@@ -28,9 +28,10 @@ interface Paris6PageProps {
   onParis4Page?: () => void;
   onParis5Page?: () => void;
   onParis7Page?: () => void;
+  onParis8Page?: () => void;
 }
 
-const Paris6Page: React.FC<Paris6PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis7Page }) => {
+const Paris6Page: React.FC<Paris6PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis7Page, onParis8Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -320,6 +321,7 @@ const Paris6Page: React.FC<Paris6PageProps> = ({ onBack, onQuoteRequest, onPhoto
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onBack },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>

--- a/src/components/Paris7Page.tsx
+++ b/src/components/Paris7Page.tsx
@@ -27,9 +27,10 @@ interface Paris7PageProps {
   onParis4Page?: () => void;
   onParis5Page?: () => void;
   onParis6Page?: () => void;
+  onParis8Page?: () => void;
 }
 
-const Paris7Page: React.FC<Paris7PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page }) => {
+const Paris7Page: React.FC<Paris7PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis8Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -346,6 +347,7 @@ const Paris7Page: React.FC<Paris7PageProps> = ({ onBack, onQuoteRequest, onPhoto
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onBack },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>

--- a/src/components/Paris8Page.tsx
+++ b/src/components/Paris8Page.tsx
@@ -2,18 +2,20 @@ import React from 'react';
 import {
   ArrowLeft,
   Camera,
-  MapPin,
-  Building,
   Heart,
+  Sparkles,
+  Check,
   Star,
   Share2,
-  Shield,
-  Settings
+  Settings,
+  Eye,
+  Award,
+  Monitor
 } from 'lucide-react';
 import HomeSectionLink from './HomeSectionLink';
 import Footer from './Footer';
 
-interface Paris3PageProps {
+interface Paris8PageProps {
   onBack: () => void;
   onQuoteRequest?: () => void;
   onPhotoboothDetails?: () => void;
@@ -21,14 +23,27 @@ interface Paris3PageProps {
   onSEOPage?: () => void;
   onParis1Page?: () => void;
   onParis2Page?: () => void;
+  onParis3Page?: () => void;
   onParis4Page?: () => void;
   onParis5Page?: () => void;
   onParis6Page?: () => void;
   onParis7Page?: () => void;
-  onParis8Page?: () => void;
 }
 
-const Paris3Page: React.FC<Paris3PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page }) => {
+const Paris8Page: React.FC<Paris8PageProps> = ({
+  onBack,
+  onQuoteRequest,
+  onPhotoboothDetails,
+  onAIAnimations,
+  onSEOPage,
+  onParis1Page,
+  onParis2Page,
+  onParis3Page,
+  onParis4Page,
+  onParis5Page,
+  onParis6Page,
+  onParis7Page,
+}) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -43,27 +58,27 @@ const Paris3Page: React.FC<Paris3PageProps> = ({ onBack, onQuoteRequest, onPhoto
             </div>
 
             <nav className="hidden lg:flex items-center space-x-8">
-              <button 
+              <button
                 onClick={onBack}
                 className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
               >
                 Accueil
               </button>
-              <button 
+              <button
                 onClick={onPhotoboothDetails}
                 className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
               >
                 Photobooth sur mesure
               </button>
               <HomeSectionLink label="Événements Privés" targetId="mariages" onBack={onBack} />
-              <button 
+              <button
                 onClick={onAIAnimations}
                 className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
               >
                 Animations IA
               </button>
               <HomeSectionLink label="Galerie" targetId="galerie" onBack={onBack} />
-              <button 
+              <button
                 onClick={onQuoteRequest}
                 className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
               >
@@ -71,7 +86,7 @@ const Paris3Page: React.FC<Paris3PageProps> = ({ onBack, onQuoteRequest, onPhoto
               </button>
             </nav>
 
-            <button 
+            <button
               onClick={onBack}
               className="lg:hidden flex items-center space-x-2 text-gray-600 hover:text-gray-800 transition-colors"
             >
@@ -87,15 +102,9 @@ const Paris3Page: React.FC<Paris3PageProps> = ({ onBack, onQuoteRequest, onPhoto
         <div className="max-w-7xl mx-auto px-6">
           <div className="text-center mb-16">
             <h1 className="text-4xl lg:text-6xl font-bold text-black mb-6 leading-tight">
-              Photobooth
-              <span className="text-yellow-400 relative">
-                {' '}Paris 3
-                <div className="absolute -bottom-2 left-0 w-full h-3 bg-yellow-400 -z-10"></div>
-              </span>
+              Louer un photobooth
+              <span className="text-yellow-400 relative">{' '}Paris 8<div className="absolute -bottom-2 left-0 w-full h-3 bg-yellow-400 -z-10"></div></span>
             </h1>
-            <h2 className="text-2xl lg:text-3xl font-semibold text-gray-600 mb-8">
-              Immortalisez vos événements
-            </h2>
           </div>
         </div>
       </section>
@@ -110,16 +119,16 @@ const Paris3Page: React.FC<Paris3PageProps> = ({ onBack, onQuoteRequest, onPhoto
                 <div className="w-12 h-12 bg-yellow-400 rounded-xl flex items-center justify-center">
                   <Heart className="w-6 h-6 text-black" />
                 </div>
-                <h2 className="text-3xl font-bold text-black">Photobooth Paris 3 : Immortalisez vos événements</h2>
+                <h2 className="text-3xl font-bold text-black">Location photobooth Paris 8</h2>
               </div>
               <p className="text-gray-700 text-lg leading-relaxed mb-6">
-                Imaginez Paris, la ville lumière, où chaque pierre du Marais murmure des siècles d'histoire, où la Place de la République devient le carrefour des rencontres inattendues, et où la Rue de Bretagne dévoile des trésors d'art contemporain à ciel ouvert. Dans le 3ème arrondissement, l'âme bohème des cours cachées dialogue avec l'énergie créative des concept-stores.
-              </p>
-              <p className="text-gray-700 text-lg leading-relaxed">
-                C'est ici, entre passé et présent, que vos événements méritent d'être transcendés. Plongez dans l'expérience avec nos photobooths, bien plus que des appareils : des complices de mémoire, ajustés sur mesure à votre univers.
+                Avec ses avenues prestigieuses et ses monuments mythiques comme les Champs-Élysées,
+                l'Arc de Triomphe ou la Place de la Concorde, le 8ème arrondissement est un écrin
+                d'exception pour vos événements. The Pix vous propose d'y installer un photobooth
+                pour sublimer vos réceptions privées ou professionnelles.
               </p>
               <div className="mt-8">
-                <button 
+                <button
                   onClick={onQuoteRequest}
                   className="bg-yellow-400 text-black px-8 py-4 rounded-full hover:bg-yellow-500 transition-colors font-semibold text-lg"
                 >
@@ -129,102 +138,140 @@ const Paris3Page: React.FC<Paris3PageProps> = ({ onBack, onQuoteRequest, onPhoto
             </div>
           </section>
 
-          {/* Le Photobooth Paris 3 Revisité */}
+          {/* Photobooth tendance */}
           <section className="mb-16">
             <div className="bg-gray-50 p-8 rounded-2xl">
               <div className="flex items-center space-x-4 mb-6">
                 <div className="w-12 h-12 bg-blue-500 rounded-xl flex items-center justify-center">
-                  <MapPin className="w-6 h-6 text-white" />
+                  <Sparkles className="w-6 h-6 text-white" />
                 </div>
-                <h2 className="text-3xl font-bold text-black">Le Photobooth Paris 3 Revisité</h2>
+                <h2 className="text-3xl font-bold text-black">Le photobooth : l'animation tendance dans la capitale</h2>
               </div>
               <p className="text-gray-700 text-lg leading-relaxed mb-6">
-                Pour une location de photobooth à Paris, The Pix incarne l'adresse à retenir. Oubliez les bornes photo impersonnelles : nos cabines sont une invitation à capturer l'âme vibrante du Paris historique, des arcades du Marais aux échoppes gourmandes de la Rue de Bretagne. L'authenticité, sans les clichés.
+                Mariage sur l'avenue Montaigne, cocktail professionnel au pied de l'Arc de Triomphe
+                ou soirée étudiante près des Champs-Élysées : la borne à selfie apporte une touche
+                d'originalité et de convivialité à tout rassemblement.
               </p>
-              <div className="bg-white p-6 rounded-xl">
-                <h3 className="font-bold text-black mb-3 text-xl">location photobooth paris 3</h3>
+              <div className="mt-6 bg-white p-6 rounded-xl">
+                <h3 className="font-bold text-black mb-3 text-xl">location photobooth paris 8</h3>
                 <p className="text-gray-700">
-                  Notre technologie haut de gamme épouse naturellement le rythme du quartier. Elle saisit les éclats de joie près du Canal Saint-Martin, les discussions animées à deux pas de la Place de la République, ces secondes où le temps semble suspendre son vol. Un rendu d'une netteté remarquable, pour des souvenirs aussi vivants que votre événement.
+                  Vos invités se prennent en photo et repartent avec leurs souvenirs numériques grâce
+                  à notre cabine dernière génération. Une animation incontournable pour une ambiance
+                  joyeuse et festive.
                 </p>
               </div>
             </div>
           </section>
 
-          {/* L'Art de l'Événement d'Affaires */}
+          {/* Technologies */}
           <section className="mb-16">
             <div className="bg-white p-8 rounded-2xl shadow-sm border border-gray-100">
               <div className="flex items-center space-x-4 mb-6">
                 <div className="w-12 h-12 bg-purple-500 rounded-xl flex items-center justify-center">
-                  <Building className="w-6 h-6 text-white" />
+                  <Monitor className="w-6 h-6 text-white" />
                 </div>
-                <h2 className="text-3xl font-bold text-black">L'Art de l'Événement d'Affaires</h2>
+                <h2 className="text-3xl font-bold text-black">Une cabine photo dotée des dernières technologies</h2>
               </div>
-              <p className="text-gray-700 text-lg leading-relaxed">
-                Dans l'effervescence des rendez-vous professionnels – inauguration, soirée d'entreprise ou colloque – l'excellence se doit d'être sans compromis. Nos photobooths, au design épuré, s'effacent pour mettre en lumière vos invités. Une animation discrète mais impactante, où chaque cliché devient un ambassadeur de votre marque. Redéfinissez les codes des événements en Île-de-France.
+              <p className="text-gray-700 text-lg leading-relaxed mb-6">
+                Nos bornes selfie intègrent des équipements haut de gamme pour une expérience optimale :
               </p>
+              <div className="grid md:grid-cols-2 gap-6">
+                <div className="bg-gray-50 p-6 rounded-xl">
+                  <ul className="space-y-3">
+                    <li className="flex items-center space-x-3">
+                      <Check className="w-5 h-5 text-green-500" />
+                      <span className="text-gray-700">Appareils photo reflex professionnels</span>
+                    </li>
+                    <li className="flex items-center space-x-3">
+                      <Check className="w-5 h-5 text-green-500" />
+                      <span className="text-gray-700">Écrans tactiles HD</span>
+                    </li>
+                    <li className="flex items-center space-x-3">
+                      <Check className="w-5 h-5 text-green-500" />
+                      <span className="text-gray-700">Impression instantanée des photos</span>
+                    </li>
+                  </ul>
+                </div>
+                <div className="bg-gray-50 p-6 rounded-xl">
+                  <ul className="space-y-3">
+                    <li className="flex items-center space-x-3">
+                      <Check className="w-5 h-5 text-green-500" />
+                      <span className="text-gray-700">Partage immédiat sur les réseaux</span>
+                    </li>
+                    <li className="flex items-center space-x-3">
+                      <Check className="w-5 h-5 text-green-500" />
+                      <span className="text-gray-700">Grand choix d'accessoires drôles</span>
+                    </li>
+                    <li className="flex items-center space-x-3">
+                      <Check className="w-5 h-5 text-green-500" />
+                      <span className="text-gray-700">Personnalisation des fonds et de l'habillage</span>
+                    </li>
+                  </ul>
+                </div>
+              </div>
             </div>
           </section>
 
-          {/* Votre Réservation, Simplissime */}
+          {/* Réservation */}
           <section className="mb-16">
             <div className="bg-gradient-to-br from-yellow-50 to-orange-50 p-8 rounded-2xl">
               <div className="flex items-center space-x-4 mb-6">
                 <div className="w-12 h-12 bg-orange-500 rounded-xl flex items-center justify-center">
                   <Settings className="w-6 h-6 text-white" />
                 </div>
-                <h2 className="text-3xl font-bold text-black">Votre Réservation, Simplissime</h2>
+                <h2 className="text-3xl font-bold text-black">Réservez votre photobooth en quelques clics</h2>
               </div>
               <p className="text-gray-700 text-lg leading-relaxed mb-6">
-                Organiser un événement à Paris relève parfois du défi. Avec The Pix, libérez-vous des contraintes logistiques. Aucun formulaire interminable ni processus alambiqué : quelques clics suffisent pour bloquer votre date.
-              </p>
-              <p className="text-gray-700 text-lg leading-relaxed">
-                Choix du lieu, options de personnalisation, livraison clé en main – notre équipe orchestre chaque détail avec la précision d'un horloger. Vous n'aurez qu'à profiter de l'instant.
+                Notre site web accessible 7j/7 permet de réserver facilement : indiquez la date, le
+                lieu et vos options, nous gérons le transport, l'installation et le démontage.
               </p>
             </div>
           </section>
 
-          {/* L'instant magique, prolongé sur les réseaux */}
+          {/* Partage */}
           <section className="mb-16">
             <div className="bg-gradient-to-br from-purple-50 to-blue-50 p-8 rounded-2xl">
               <div className="flex items-center space-x-4 mb-6">
                 <div className="w-12 h-12 bg-purple-500 rounded-xl flex items-center justify-center">
                   <Share2 className="w-6 h-6 text-white" />
                 </div>
-                <h2 className="text-3xl font-bold text-black">L'instant magique, prolongé sur les réseaux</h2>
+                <h2 className="text-3xl font-bold text-black">Partagez vos moments forts</h2>
               </div>
               <p className="text-gray-700 text-lg leading-relaxed mb-6">
-                À l'ère où chaque émotion appelle au partage, notre photobooth à Paris 3 devient votre allié digital. Les sourires fusent, les poses s'enchaînent, et les clichés s'envolent en direct vers les réseaux sociaux.
+                Les photos peuvent être diffusées instantanément sur les réseaux sociaux ou dans notre
+                galerie. Créez un hashtag dédié pour prolonger la fête au-delà de votre événement.
               </p>
-              <p className="text-gray-700 text-lg leading-relaxed">
-                Une viralité élégante qui prolonge la vie de votre événement tout en boostant votre visibilité. L'interaction devient mémoire, et la mémoire, promotion.
-              </p>
-              <div className="mt-6 bg-white p-6 rounded-xl">
-                <p className="text-gray-700">
-                  <button 
-                    onClick={onParis2Page}
-                    className="text-blue-600 hover:text-blue-800 transition-colors underline"
-                  >
-                    Découvrez aussi nos services sur Paris 2.
-                  </button>
-                </p>
-              </div>
             </div>
           </section>
 
-          {/* Notre Engagement : Votre Sérénité */}
+          {/* Image de marque */}
           <section className="mb-16">
             <div className="bg-white p-8 rounded-2xl shadow-sm border border-gray-100">
               <div className="flex items-center space-x-4 mb-6">
                 <div className="w-12 h-12 bg-green-500 rounded-xl flex items-center justify-center">
-                  <Shield className="w-6 h-6 text-white" />
+                  <Eye className="w-6 h-6 text-white" />
                 </div>
-                <h2 className="text-3xl font-bold text-black">Notre Engagement : Votre Sérénité</h2>
+                <h2 className="text-3xl font-bold text-black">Un accessoire tendance pour votre image</h2>
               </div>
               <p className="text-gray-700 text-lg leading-relaxed mb-6">
-                Confier votre événement à notre équipe, c'est choisir la tranquillité d'esprit. Besoin d'un conseil pour l'emplacement idéal ? D'une charte graphique alignée sur votre identité ? Nos experts déploient des solutions sur mesure, avec la réactivité qui caractérise Paris.
+                Grâce à la personnalisation de l'habillage, des accessoires ou des tirages, le
+                photobooth reflète votre univers et renforce votre notoriété.
               </p>
-              <p className="text-gray-700 text-lg leading-relaxed">
-                Car ici, chaque projet est traité avec la passion d'un premier rendez-vous.
+            </div>
+          </section>
+
+          {/* Équipe */}
+          <section className="mb-16">
+            <div className="bg-gray-50 p-8 rounded-2xl">
+              <div className="flex items-center space-x-4 mb-6">
+                <div className="w-12 h-12 bg-red-500 rounded-xl flex items-center justify-center">
+                  <Award className="w-6 h-6 text-white" />
+                </div>
+                <h2 className="text-3xl font-bold text-black">Une équipe d'experts à votre écoute</h2>
+              </div>
+              <p className="text-gray-700 text-lg leading-relaxed mb-6">
+                Notre équipe vous accompagne de A à Z pour louer et installer facilement votre
+                photobooth au cœur de Paris.
               </p>
             </div>
           </section>
@@ -236,18 +283,15 @@ const Paris3Page: React.FC<Paris3PageProps> = ({ onBack, onQuoteRequest, onPhoto
                 <div className="w-12 h-12 bg-yellow-400 rounded-xl flex items-center justify-center">
                   <Star className="w-6 h-6 text-black" />
                 </div>
-                <h2 className="text-3xl font-bold text-black">Paris ne se livre pas, elle se vit</h2>
+                <h2 className="text-3xl font-bold text-black">Prêt à faire sourire vos invités ?</h2>
               </div>
-              <p className="text-gray-700 text-lg leading-relaxed mb-6">
-                À travers nos photobooths, offrez à vos invités un fragment de cette magie – des instants volés, transformés en héritage tangible.
-              </p>
               <div className="bg-white p-6 rounded-xl">
-                <h3 className="font-bold text-black mb-4 text-xl">Prêt à transformer votre événement en une expérience inoubliable ?</h3>
+                <h3 className="font-bold text-black mb-4 text-xl">Réservez votre photobooth à Paris 8 dès maintenant</h3>
                 <p className="text-gray-700 mb-6">
-                  Réservez dès maintenant votre photobooth dans le 3ème arrondissement de Paris et créez des souvenirs exceptionnels pour vos invités.
+                  Faites de votre événement un moment inoubliable avec The Pix.
                 </p>
                 <div className="flex flex-col sm:flex-row gap-4">
-                  <button 
+                  <button
                     onClick={onQuoteRequest}
                     className="bg-yellow-400 text-black px-8 py-4 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
                   >
@@ -267,16 +311,16 @@ const Paris3Page: React.FC<Paris3PageProps> = ({ onBack, onQuoteRequest, onPhoto
         arrondissementLinks={[
           { label: 'Location photobooth Paris 1', onClick: onParis1Page },
           { label: 'Location photobooth Paris 2', onClick: onParis2Page },
-          { label: 'Location photobooth Paris 3', onClick: onBack },
+          { label: 'Location photobooth Paris 3', onClick: onParis3Page },
           { label: 'Location photobooth Paris 4', onClick: onParis4Page },
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
-          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
+          { label: 'Location photobooth Paris 8', onClick: onBack },
         ]}
       />
     </div>
   );
 };
 
-export default Paris3Page;
+export default Paris8Page;

--- a/src/components/PhotoboothDetailsPage.tsx
+++ b/src/components/PhotoboothDetailsPage.tsx
@@ -26,10 +26,11 @@ interface PhotoboothDetailsPageProps {
   onParis5Page?: () => void;
   onParis6Page?: () => void;
   onParis7Page?: () => void;
+  onParis8Page?: () => void;
   onQuoteRequest?: () => void;
 }
 
-const PhotoboothDetailsPage: React.FC<PhotoboothDetailsPageProps> = ({ onBack, onAIAnimations, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onQuoteRequest }) => {
+const PhotoboothDetailsPage: React.FC<PhotoboothDetailsPageProps> = ({ onBack, onAIAnimations, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onQuoteRequest }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -541,6 +542,7 @@ const PhotoboothDetailsPage: React.FC<PhotoboothDetailsPageProps> = ({ onBack, o
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>

--- a/src/components/PhotographerAIPage.tsx
+++ b/src/components/PhotographerAIPage.tsx
@@ -33,9 +33,10 @@ interface PhotographerAIPageProps {
   onParis5Page?: () => void;
   onParis6Page?: () => void;
   onParis7Page?: () => void;
+  onParis8Page?: () => void;
 }
 
-const PhotographerAIPage: React.FC<PhotographerAIPageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page }) => {
+const PhotographerAIPage: React.FC<PhotographerAIPageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -515,6 +516,7 @@ const PhotographerAIPage: React.FC<PhotographerAIPageProps> = ({ onBack, onQuote
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>

--- a/src/components/QuotePage.tsx
+++ b/src/components/QuotePage.tsx
@@ -24,9 +24,10 @@ interface QuotePageProps {
   onParis5Page?: () => void;
   onParis6Page?: () => void;
   onParis7Page?: () => void;
+  onParis8Page?: () => void;
 }
 
-const QuotePage: React.FC<QuotePageProps> = ({ onBack, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page }) => {
+const QuotePage: React.FC<QuotePageProps> = ({ onBack, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page }) => {
   const [currentStep, setCurrentStep] = useState(1);
   const [formData, setFormData] = useState({
     clientType: '', // 'enterprise' or 'wedding'
@@ -550,6 +551,7 @@ const QuotePage: React.FC<QuotePageProps> = ({ onBack, onSEOPage, onParis1Page, 
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>

--- a/src/components/SEOPage.tsx
+++ b/src/components/SEOPage.tsx
@@ -29,9 +29,10 @@ interface SEOPageProps {
   onParis5Page?: () => void;
   onParis6Page?: () => void;
   onParis7Page?: () => void;
+  onParis8Page?: () => void;
 }
 
-const SEOPage: React.FC<SEOPageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page }) => {
+const SEOPage: React.FC<SEOPageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -488,6 +489,7 @@ const SEOPage: React.FC<SEOPageProps> = ({ onBack, onQuoteRequest, onPhotoboothD
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>


### PR DESCRIPTION
## Summary
- add dedicated Paris 8 photobooth landing page
- wire Paris 8 into navigation and quote workflow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8137c33488331a12f6f42372bd9a4