### PR TITLE
feat: expand Paris 8 photobooth page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import Paris4Page from './components/Paris4Page';
 import Paris5Page from './components/Paris5Page';
 import Paris6Page from './components/Paris6Page';
 import Paris7Page from './components/Paris7Page';
+import Paris8Page from './components/Paris8Page';
 import { 
   Camera,
   Sparkles,
@@ -49,6 +50,7 @@ function App() {
   const [showParis5Page, setShowParis5Page] = useState(false);
   const [showParis6Page, setShowParis6Page] = useState(false);
   const [showParis7Page, setShowParis7Page] = useState(false);
+  const [showParis8Page, setShowParis8Page] = useState(false);
   const [previousPage, setPreviousPage] = useState<string>('home');
 
   // Fonction pour remettre le scroll en haut
@@ -59,7 +61,7 @@ function App() {
   // Effet pour remettre le scroll en haut quand on change de page
   useEffect(() => {
     scrollToTop();
-  }, [showQuotePage, showPhotoboothDetails, showAIAnimations, showDemoRequest, showSEOPage, showPhotographerAI, showParis1Page, showParis2Page, showParis3Page, showParis4Page, showParis5Page, showParis6Page, showParis7Page]);
+  }, [showQuotePage, showPhotoboothDetails, showAIAnimations, showDemoRequest, showSEOPage, showPhotographerAI, showParis1Page, showParis2Page, showParis3Page, showParis4Page, showParis5Page, showParis6Page, showParis7Page, showParis8Page]);
 
   // Fonction pour gérer le retour depuis la page de devis
   const handleQuotePageBack = () => {
@@ -92,6 +94,9 @@ function App() {
         break;
       case 'paris7':
         setShowParis7Page(true);
+        break;
+      case 'paris8':
+        setShowParis8Page(true);
         break;
       default:
         // Rester sur la page principale
@@ -140,6 +145,10 @@ function App() {
         setShowQuotePage(false);
         setShowParis7Page(true);
       }}
+      onParis8Page={() => {
+        setShowQuotePage(false);
+        setShowParis8Page(true);
+      }}
     />;
   }
 
@@ -181,6 +190,10 @@ function App() {
       onParis7Page={() => {
         setShowPhotoboothDetails(false);
         setShowParis7Page(true);
+      }}
+      onParis8Page={() => {
+        setShowPhotoboothDetails(false);
+        setShowParis8Page(true);
       }}
       onQuoteRequest={() => {
         setShowPhotoboothDetails(false);
@@ -232,6 +245,10 @@ function App() {
         setShowAIAnimations(false);
         setShowParis7Page(true);
       }}
+      onParis8Page={() => {
+        setShowAIAnimations(false);
+        setShowParis8Page(true);
+      }}
       onQuoteRequest={() => {
         setShowAIAnimations(false);
         openQuotePage('aiAnimations');
@@ -273,6 +290,10 @@ function App() {
       onParis7Page={() => {
         setShowDemoRequest(false);
         setShowParis7Page(true);
+      }}
+      onParis8Page={() => {
+        setShowDemoRequest(false);
+        setShowParis8Page(true);
       }}
       onQuoteRequest={() => {
         setShowDemoRequest(false);
@@ -324,6 +345,10 @@ function App() {
         setShowSEOPage(false);
         setShowParis7Page(true);
       }}
+      onParis8Page={() => {
+        setShowSEOPage(false);
+        setShowParis8Page(true);
+      }}
     />;
   }
 
@@ -374,6 +399,10 @@ function App() {
         setShowPhotographerAI(false);
         setShowParis7Page(true);
       }}
+      onParis8Page={() => {
+        setShowPhotographerAI(false);
+        setShowParis8Page(true);
+      }}
     />;
   }
 
@@ -419,6 +448,10 @@ function App() {
       onParis7Page={() => {
         setShowParis1Page(false);
         setShowParis7Page(true);
+      }}
+      onParis8Page={() => {
+        setShowParis1Page(false);
+        setShowParis8Page(true);
       }}
     />;
   }
@@ -466,6 +499,10 @@ function App() {
         setShowParis2Page(false);
         setShowParis7Page(true);
       }}
+      onParis8Page={() => {
+        setShowParis2Page(false);
+        setShowParis8Page(true);
+      }}
     />;
   }
 
@@ -511,6 +548,10 @@ function App() {
       onParis7Page={() => {
         setShowParis3Page(false);
         setShowParis7Page(true);
+      }}
+      onParis8Page={() => {
+        setShowParis3Page(false);
+        setShowParis8Page(true);
       }}
     />;
   }
@@ -558,6 +599,10 @@ function App() {
         setShowParis4Page(false);
         setShowParis7Page(true);
       }}
+      onParis8Page={() => {
+        setShowParis4Page(false);
+        setShowParis8Page(true);
+      }}
     />;
   }
 
@@ -603,6 +648,10 @@ function App() {
       onParis7Page={() => {
         setShowParis5Page(false);
         setShowParis7Page(true);
+      }}
+      onParis8Page={() => {
+        setShowParis5Page(false);
+        setShowParis8Page(true);
       }}
     />;
   }
@@ -650,12 +699,16 @@ function App() {
         setShowParis6Page(false);
         setShowParis7Page(true);
       }}
+      onParis8Page={() => {
+        setShowParis6Page(false);
+        setShowParis8Page(true);
+      }}
     />;
   }
 
   if (showParis7Page) {
-    return <Paris7Page 
-      onBack={() => setShowParis7Page(false)} 
+    return <Paris7Page
+      onBack={() => setShowParis7Page(false)}
       onQuoteRequest={() => {
         setShowParis7Page(false);
         openQuotePage('paris7');
@@ -695,6 +748,60 @@ function App() {
       onParis6Page={() => {
         setShowParis7Page(false);
         setShowParis6Page(true);
+      }}
+      onParis8Page={() => {
+        setShowParis7Page(false);
+        setShowParis8Page(true);
+      }}
+    />;
+  }
+
+  if (showParis8Page) {
+    return <Paris8Page
+      onBack={() => setShowParis8Page(false)}
+      onQuoteRequest={() => {
+        setShowParis8Page(false);
+        openQuotePage('paris8');
+      }}
+      onPhotoboothDetails={() => {
+        setShowParis8Page(false);
+        setShowPhotoboothDetails(true);
+      }}
+      onAIAnimations={() => {
+        setShowParis8Page(false);
+        setShowAIAnimations(true);
+      }}
+      onSEOPage={() => {
+        setShowParis8Page(false);
+        setShowSEOPage(true);
+      }}
+      onParis1Page={() => {
+        setShowParis8Page(false);
+        setShowParis1Page(true);
+      }}
+      onParis2Page={() => {
+        setShowParis8Page(false);
+        setShowParis2Page(true);
+      }}
+      onParis3Page={() => {
+        setShowParis8Page(false);
+        setShowParis3Page(true);
+      }}
+      onParis4Page={() => {
+        setShowParis8Page(false);
+        setShowParis4Page(true);
+      }}
+      onParis5Page={() => {
+        setShowParis8Page(false);
+        setShowParis5Page(true);
+      }}
+      onParis6Page={() => {
+        setShowParis8Page(false);
+        setShowParis6Page(true);
+      }}
+      onParis7Page={() => {
+        setShowParis8Page(false);
+        setShowParis7Page(true);
       }}
     />;
   }
@@ -1505,11 +1612,17 @@ function App() {
                 >
                   Location photobooth Paris 6
                 </button>
-                <button 
+                <button
                   onClick={() => setShowParis7Page(true)}
                   className="block text-gray-600 hover:text-yellow-500 transition-colors text-left"
                 >
                   Location photobooth Paris 7
+                </button>
+                <button
+                  onClick={() => setShowParis8Page(true)}
+                  className="block text-gray-600 hover:text-yellow-500 transition-colors text-left"
+                >
+                  Location photobooth Paris 8
                 </button>
               </div>
             </div>

--- a/src/components/AIAnimationsPage.tsx
+++ b/src/components/AIAnimationsPage.tsx
@@ -35,10 +35,11 @@ interface AIAnimationsPageProps {
   onParis5Page?: () => void;
   onParis6Page?: () => void;
   onParis7Page?: () => void;
+  onParis8Page?: () => void;
   onQuoteRequest?: () => void;
 }
 
-const AIAnimationsPage: React.FC<AIAnimationsPageProps> = ({ onBack, onDemoRequest, onPhotoboothDetails, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onQuoteRequest }) => {
+const AIAnimationsPage: React.FC<AIAnimationsPageProps> = ({ onBack, onDemoRequest, onPhotoboothDetails, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onQuoteRequest }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -563,6 +564,7 @@ const AIAnimationsPage: React.FC<AIAnimationsPageProps> = ({ onBack, onDemoReque
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>

--- a/src/components/DemoRequestPage.tsx
+++ b/src/components/DemoRequestPage.tsx
@@ -27,10 +27,11 @@ interface DemoRequestPageProps {
   onParis5Page?: () => void;
   onParis6Page?: () => void;
   onParis7Page?: () => void;
+  onParis8Page?: () => void;
   onQuoteRequest?: () => void;
 }
 
-const DemoRequestPage: React.FC<DemoRequestPageProps> = ({ onBack, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onQuoteRequest }) => {
+const DemoRequestPage: React.FC<DemoRequestPageProps> = ({ onBack, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onQuoteRequest }) => {
   const [currentStep, setCurrentStep] = useState(1);
   const [formData, setFormData] = useState({
     demoType: '', // 'live' or 'video'
@@ -473,6 +474,7 @@ const DemoRequestPage: React.FC<DemoRequestPageProps> = ({ onBack, onSEOPage, on
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>

--- a/src/components/Paris1Page.tsx
+++ b/src/components/Paris1Page.tsx
@@ -25,9 +25,10 @@ interface Paris1PageProps {
   onParis5Page?: () => void;
   onParis6Page?: () => void;
   onParis7Page?: () => void;
+  onParis8Page?: () => void;
 }
 
-const Paris1Page: React.FC<Paris1PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page }) => {
+const Paris1Page: React.FC<Paris1PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -326,6 +327,7 @@ const Paris1Page: React.FC<Paris1PageProps> = ({ onBack, onQuoteRequest, onPhoto
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>

--- a/src/components/Paris2Page.tsx
+++ b/src/components/Paris2Page.tsx
@@ -22,9 +22,10 @@ interface Paris2PageProps {
   onParis5Page?: () => void;
   onParis6Page?: () => void;
   onParis7Page?: () => void;
+  onParis8Page?: () => void;
 }
 
-const Paris2Page: React.FC<Paris2PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page }) => {
+const Paris2Page: React.FC<Paris2PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -283,6 +284,7 @@ const Paris2Page: React.FC<Paris2PageProps> = ({ onBack, onQuoteRequest, onPhoto
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>

--- a/src/components/Paris3Page.tsx
+++ b/src/components/Paris3Page.tsx
@@ -25,9 +25,10 @@ interface Paris3PageProps {
   onParis5Page?: () => void;
   onParis6Page?: () => void;
   onParis7Page?: () => void;
+  onParis8Page?: () => void;
 }
 
-const Paris3Page: React.FC<Paris3PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page }) => {
+const Paris3Page: React.FC<Paris3PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -271,6 +272,7 @@ const Paris3Page: React.FC<Paris3PageProps> = ({ onBack, onQuoteRequest, onPhoto
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>

--- a/src/components/Paris4Page.tsx
+++ b/src/components/Paris4Page.tsx
@@ -25,9 +25,10 @@ interface Paris4PageProps {
   onParis5Page?: () => void;
   onParis6Page?: () => void;
   onParis7Page?: () => void;
+  onParis8Page?: () => void;
 }
 
-const Paris4Page: React.FC<Paris4PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis5Page, onParis6Page, onParis7Page }) => {
+const Paris4Page: React.FC<Paris4PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -273,6 +274,7 @@ const Paris4Page: React.FC<Paris4PageProps> = ({ onBack, onQuoteRequest, onPhoto
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>

--- a/src/components/Paris5Page.tsx
+++ b/src/components/Paris5Page.tsx
@@ -26,9 +26,10 @@ interface Paris5PageProps {
   onParis4Page?: () => void;
   onParis6Page?: () => void;
   onParis7Page?: () => void;
+  onParis8Page?: () => void;
 }
 
-const Paris5Page: React.FC<Paris5PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis6Page, onParis7Page }) => {
+const Paris5Page: React.FC<Paris5PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis6Page, onParis7Page, onParis8Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -265,6 +266,7 @@ const Paris5Page: React.FC<Paris5PageProps> = ({ onBack, onQuoteRequest, onPhoto
           { label: 'Location photobooth Paris 5', onClick: onBack },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>

--- a/src/components/Paris6Page.tsx
+++ b/src/components/Paris6Page.tsx
@@ -28,9 +28,10 @@ interface Paris6PageProps {
   onParis4Page?: () => void;
   onParis5Page?: () => void;
   onParis7Page?: () => void;
+  onParis8Page?: () => void;
 }
 
-const Paris6Page: React.FC<Paris6PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis7Page }) => {
+const Paris6Page: React.FC<Paris6PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis7Page, onParis8Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -320,6 +321,7 @@ const Paris6Page: React.FC<Paris6PageProps> = ({ onBack, onQuoteRequest, onPhoto
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onBack },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>

--- a/src/components/Paris8Page.tsx
+++ b/src/components/Paris8Page.tsx
@@ -6,16 +6,16 @@ import {
   Sparkles,
   Check,
   Star,
-  Award,
   Share2,
-  Eye,
   Settings,
+  Eye,
+  Award,
   Monitor
 } from 'lucide-react';
 import HomeSectionLink from './HomeSectionLink';
 import Footer from './Footer';
 
-interface Paris7PageProps {
+interface Paris8PageProps {
   onBack: () => void;
   onQuoteRequest?: () => void;
   onPhotoboothDetails?: () => void;
@@ -27,10 +27,23 @@ interface Paris7PageProps {
   onParis4Page?: () => void;
   onParis5Page?: () => void;
   onParis6Page?: () => void;
-  onParis8Page?: () => void;
+  onParis7Page?: () => void;
 }
 
-const Paris7Page: React.FC<Paris7PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis8Page }) => {
+const Paris8Page: React.FC<Paris8PageProps> = ({
+  onBack,
+  onQuoteRequest,
+  onPhotoboothDetails,
+  onAIAnimations,
+  onSEOPage,
+  onParis1Page,
+  onParis2Page,
+  onParis3Page,
+  onParis4Page,
+  onParis5Page,
+  onParis6Page,
+  onParis7Page,
+}) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -45,27 +58,27 @@ const Paris7Page: React.FC<Paris7PageProps> = ({ onBack, onQuoteRequest, onPhoto
             </div>
 
             <nav className="hidden lg:flex items-center space-x-8">
-              <button 
+              <button
                 onClick={onBack}
                 className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
               >
                 Accueil
               </button>
-              <button 
+              <button
                 onClick={onPhotoboothDetails}
                 className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
               >
                 Photobooth sur mesure
               </button>
               <HomeSectionLink label="Événements Privés" targetId="mariages" onBack={onBack} />
-              <button 
+              <button
                 onClick={onAIAnimations}
                 className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
               >
                 Animations IA
               </button>
               <HomeSectionLink label="Galerie" targetId="galerie" onBack={onBack} />
-              <button 
+              <button
                 onClick={onQuoteRequest}
                 className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
               >
@@ -73,7 +86,7 @@ const Paris7Page: React.FC<Paris7PageProps> = ({ onBack, onQuoteRequest, onPhoto
               </button>
             </nav>
 
-            <button 
+            <button
               onClick={onBack}
               className="lg:hidden flex items-center space-x-2 text-gray-600 hover:text-gray-800 transition-colors"
             >
@@ -89,11 +102,8 @@ const Paris7Page: React.FC<Paris7PageProps> = ({ onBack, onQuoteRequest, onPhoto
         <div className="max-w-7xl mx-auto px-6">
           <div className="text-center mb-16">
             <h1 className="text-4xl lg:text-6xl font-bold text-black mb-6 leading-tight">
-              Location un photobooth
-              <span className="text-yellow-400 relative">
-                {' '}Paris 7
-                <div className="absolute -bottom-2 left-0 w-full h-3 bg-yellow-400 -z-10"></div>
-              </span>
+              Louer un photobooth
+              <span className="text-yellow-400 relative">{' '}Paris 8<div className="absolute -bottom-2 left-0 w-full h-3 bg-yellow-400 -z-10"></div></span>
             </h1>
           </div>
         </div>
@@ -109,13 +119,16 @@ const Paris7Page: React.FC<Paris7PageProps> = ({ onBack, onQuoteRequest, onPhoto
                 <div className="w-12 h-12 bg-yellow-400 rounded-xl flex items-center justify-center">
                   <Heart className="w-6 h-6 text-black" />
                 </div>
-                <h2 className="text-3xl font-bold text-black">Location un photobooth Paris 7</h2>
+                <h2 className="text-3xl font-bold text-black">Location photobooth Paris 8</h2>
               </div>
               <p className="text-gray-700 text-lg leading-relaxed mb-6">
-                Avec son architecture haussmannienne majestueuse et ses avenues prestigieuses comme les Champs-Élysées ou l'avenue de La Bourdonnais, le 7ème arrondissement de Paris offre un décor somptueux pour vos événements privés ou professionnels. C'est dans ce cadre unique que The Pix vous propose de louer une borne photo à selfie pour capturer vos moments les plus mémorables et créer des souvenirs impérissables.
+                Avec ses avenues prestigieuses et ses monuments mythiques comme les Champs-Élysées,
+                l'Arc de Triomphe ou la Place de la Concorde, le 8ème arrondissement est un écrin
+                d'exception pour vos événements. The Pix vous propose d'y installer un photobooth
+                pour sublimer vos réceptions privées ou professionnelles.
               </p>
               <div className="mt-8">
-                <button 
+                <button
                   onClick={onQuoteRequest}
                   className="bg-yellow-400 text-black px-8 py-4 rounded-full hover:bg-yellow-500 transition-colors font-semibold text-lg"
                 >
@@ -125,56 +138,61 @@ const Paris7Page: React.FC<Paris7PageProps> = ({ onBack, onQuoteRequest, onPhoto
             </div>
           </section>
 
-          {/* Louer une borne photobooth */}
+          {/* Photobooth tendance */}
           <section className="mb-16">
             <div className="bg-gray-50 p-8 rounded-2xl">
               <div className="flex items-center space-x-4 mb-6">
                 <div className="w-12 h-12 bg-blue-500 rounded-xl flex items-center justify-center">
                   <Sparkles className="w-6 h-6 text-white" />
                 </div>
-                <h2 className="text-3xl font-bold text-black">Louer une borne photobooth : l'animation tendance en Île-de-France</h2>
+                <h2 className="text-3xl font-bold text-black">Le photobooth : l'animation tendance dans la capitale</h2>
               </div>
               <p className="text-gray-700 text-lg leading-relaxed mb-6">
-                De plus en plus d'hôtes choisissent de louer une borne photobooth pour des événements tels que des mariages, anniversaires, lancements de produits, soirées d'entreprise, séminaires, cocktails, et plus encore. Et pour cause : la borne photobooth est une animation interactive qui permet à vos invités de se prendre en photo de façon ludique et de repartir avec une photo numérique en souvenir original. C'est devenu incontournable pour tout événement réussi, aussi bien privé que professionnel.
+                Mariage sur l'avenue Montaigne, cocktail professionnel au pied de l'Arc de Triomphe
+                ou soirée étudiante près des Champs-Élysées : la borne à selfie apporte une touche
+                d'originalité et de convivialité à tout rassemblement.
               </p>
               <p className="text-gray-700 text-lg leading-relaxed">
-                Que vous souhaitiez organiser une réception privée au Jardin du Luxembourg ou un événement professionnel à Saint-Sulpice, louer une borne photo selfie est idéal pour apporter une touche d'originalité et d'interactivité à votre rassemblement. Vos invités pourront se prendre en photo, seul ou à plusieurs, et repartir avec leurs photos numériques souvenirs grâce à notre borne photo selfie dernier cri. De quoi créer instantanément une ambiance joyeuse et conviviale !
+                Le photobooth est d'ailleurs devenu un incontournable des événements réussis,
+                apprécié autant des jeunes que des moins jeunes.
               </p>
               <div className="mt-6 bg-white p-6 rounded-xl">
-                <h3 className="font-bold text-black mb-3 text-xl">location photobooth paris 7</h3>
+                <h3 className="font-bold text-black mb-3 text-xl">location photobooth paris 8</h3>
                 <p className="text-gray-700">
-                  Vos invités auront la possibilité de se prendre en photo seul ou en groupe dans notre cabine photo dernier cri de type borne photo selfie, de personnaliser leurs clichés grâce aux nombreux filtres et accessoires rigolos, et de repartir immédiatement avec leurs photos souvenirs imprimées en impression instantanée. De quoi créer instantanément une ambiance joyeuse et festive lors de votre réception !
+                  Vos invités se prennent en photo et repartent avec leurs souvenirs numériques grâce
+                  à notre cabine dernière génération. Une animation incontournable pour une ambiance
+                  joyeuse et festive.
                 </p>
               </div>
             </div>
           </section>
 
-          {/* Une borne photo intégrant les dernières technologies */}
+          {/* Technologies */}
           <section className="mb-16">
             <div className="bg-white p-8 rounded-2xl shadow-sm border border-gray-100">
               <div className="flex items-center space-x-4 mb-6">
                 <div className="w-12 h-12 bg-purple-500 rounded-xl flex items-center justify-center">
                   <Monitor className="w-6 h-6 text-white" />
                 </div>
-                <h2 className="text-3xl font-bold text-black">Une borne photo intégrant les dernières technologies</h2>
+                <h2 className="text-3xl font-bold text-black">Une cabine photo dotée des dernières technologies</h2>
               </div>
               <p className="text-gray-700 text-lg leading-relaxed mb-6">
-                Chez The Pix, découvrez nos bornes photos dotées d'un large éventail de fonctionnalités à la pointe de la technologie :
+                Nos bornes selfie intègrent des équipements haut de gamme pour une expérience optimale :
               </p>
               <div className="grid md:grid-cols-2 gap-6">
                 <div className="bg-gray-50 p-6 rounded-xl">
                   <ul className="space-y-3">
                     <li className="flex items-center space-x-3">
                       <Check className="w-5 h-5 text-green-500" />
-                      <span className="text-gray-700">Appareil photo reflex professionnel pour des clichés haute définition</span>
+                      <span className="text-gray-700">Appareils photo reflex professionnels</span>
                     </li>
                     <li className="flex items-center space-x-3">
                       <Check className="w-5 h-5 text-green-500" />
-                      <span className="text-gray-700">Écran tactile dernière génération pour personnaliser facilement vos photos</span>
+                      <span className="text-gray-700">Écrans tactiles HD de dernière génération</span>
                     </li>
                     <li className="flex items-center space-x-3">
                       <Check className="w-5 h-5 text-green-500" />
-                      <span className="text-gray-700">Imprimante intégrée pour un tirage instantané de vos photos souvenirs en impression instantanée</span>
+                      <span className="text-gray-700">Impression instantanée de vos photos numériques souvenirs</span>
                     </li>
                   </ul>
                 </div>
@@ -182,128 +200,108 @@ const Paris7Page: React.FC<Paris7PageProps> = ({ onBack, onQuoteRequest, onPhoto
                   <ul className="space-y-3">
                     <li className="flex items-center space-x-3">
                       <Check className="w-5 h-5 text-green-500" />
-                      <span className="text-gray-700">Connexion Wi-Fi performante pour partager vos photos sur les réseaux sociaux dans notre galerie photo en ligne</span>
+                      <span className="text-gray-700">Partage immédiat sur les réseaux sociaux et dans notre galerie</span>
                     </li>
                     <li className="flex items-center space-x-3">
                       <Check className="w-5 h-5 text-green-500" />
-                      <span className="text-gray-700">Accessoires drôles et déguisements pour donner libre cours à votre créativité</span>
+                      <span className="text-gray-700">Grand choix d'accessoires drôles</span>
                     </li>
                     <li className="flex items-center space-x-3">
                       <Check className="w-5 h-5 text-green-500" />
-                      <span className="text-gray-700">Fonds d'écran personnalisés pour un rendu professionnel</span>
+                      <span className="text-gray-700">Personnalisation des fonds et de l'habillage</span>
                     </li>
                   </ul>
                 </div>
               </div>
-              <div className="mt-6 bg-blue-50 border-l-4 border-blue-400 p-6 rounded-r-xl">
-                <p className="text-gray-700">
-                  Grâce à ces fonctionnalités high-tech, notre borne photo garantit une animation mémorable lors de votre événement. Vos invités repartiront avec des souvenirs originaux pour prolonger la magie de votre réception à Paris 7.
-                </p>
-              </div>
             </div>
           </section>
 
-          {/* Réservez votre borne photo */}
+          {/* Réservation */}
           <section className="mb-16">
             <div className="bg-gradient-to-br from-yellow-50 to-orange-50 p-8 rounded-2xl">
               <div className="flex items-center space-x-4 mb-6">
                 <div className="w-12 h-12 bg-orange-500 rounded-xl flex items-center justify-center">
                   <Settings className="w-6 h-6 text-white" />
                 </div>
-                <h2 className="text-3xl font-bold text-black">Réservez votre borne photo en quelques clics</h2>
+                <h2 className="text-3xl font-bold text-black">Réservez votre photobooth en quelques clics</h2>
               </div>
               <p className="text-gray-700 text-lg leading-relaxed mb-6">
-                Grâce à notre site internet disponible 24/7, louer un photobooth à Paris 7 est d'une simplicité enfantine. Il vous suffit de sélectionner la date, le lieu de votre événement et les options de personnalisation de votre choix. Notre équipe gère ensuite l'ensemble de la logistique A à Z pour vous : transport, installation sur site, maintenance pendant la soirée et démontage rapide.
+                Grâce à notre site web accessible 7j/7 et 24h/24, réserver un photobooth à Paris se
+                fait en toute simplicité. Indiquez la date, le lieu de votre événement et vos
+                options préférées, et nous nous chargeons du reste ! Nous gérons toute la logistique
+                de A à Z : transport du matériel, installation sur site, maintenance pendant la
+                soirée, puis démontage. Le jour J, vous pouvez ainsi pleinement profiter de vos
+                convives !
               </p>
               <p className="text-gray-700 text-lg leading-relaxed">
-                Le jour J, vous n'avez plus qu'à vous concentrer pleinement sur vos convives et profiter de chaque instant, pendant que nous nous occupons entièrement de la borne photo. Notre équipe reste également à votre écoute pour répondre à toutes vos questions en amont comme pendant l'événement.
+                À lire :
+                <button
+                  onClick={onSEOPage}
+                  className="ml-1 text-yellow-500 hover:underline"
+                >
+                  Animer votre soirée d'entreprise avec un photobooth
+                </button>
               </p>
             </div>
           </section>
 
-          {/* Partagez vos meilleurs moments */}
+          {/* Partage */}
           <section className="mb-16">
             <div className="bg-gradient-to-br from-purple-50 to-blue-50 p-8 rounded-2xl">
               <div className="flex items-center space-x-4 mb-6">
                 <div className="w-12 h-12 bg-purple-500 rounded-xl flex items-center justify-center">
                   <Share2 className="w-6 h-6 text-white" />
                 </div>
-                <h2 className="text-3xl font-bold text-black">Partagez vos meilleurs moments sur les réseaux</h2>
+                <h2 className="text-3xl font-bold text-black">Partagez vos moments forts</h2>
               </div>
               <p className="text-gray-700 text-lg leading-relaxed mb-6">
-                La borne photo ou borne à selfie permet à vos invités de partager leurs photos les plus drôles et décalées sur les réseaux sociaux, donnant une belle visibilité à votre événement bien au-delà de Paris 7. C'est aussi une façon amusante d'immortaliser les temps forts de votre soirée. Vous pourrez même créer un hashtag dédié pour rassembler toutes les photos dans notre galerie photo !
-              </p>
-              <p className="text-gray-700 text-lg leading-relaxed">
-                Quoi de mieux que des photos spontanées prises pendant la soirée pour donner envie à ceux qui n'ont pas pu venir de participer la prochaine fois ? Grâce à la borne photo, vous assurerez un buzz digital autour de votre événement.
+                La cabine photo permet à vos invités de partager leurs plus belles photos sur les
+                réseaux sociaux et de donner une vitrine à votre événement bien au-delà de Paris 8.
+                Vous pouvez également créer un hashtag dédié pour rassembler toutes les photos
+                souvenirs et faire vivre les temps forts de votre soirée, même une fois celle-ci
+                terminée !
               </p>
             </div>
           </section>
 
-          {/* Une borne photo 100% personnalisée */}
+          {/* Image de marque */}
           <section className="mb-16">
             <div className="bg-white p-8 rounded-2xl shadow-sm border border-gray-100">
               <div className="flex items-center space-x-4 mb-6">
                 <div className="w-12 h-12 bg-green-500 rounded-xl flex items-center justify-center">
                   <Eye className="w-6 h-6 text-white" />
                 </div>
-                <h2 className="text-3xl font-bold text-black">Une borne photo 100 % personnalisée selon vos envies</h2>
+                <h2 className="text-3xl font-bold text-black">Un accessoire tendance pour une image de marque au top</h2>
               </div>
               <p className="text-gray-700 text-lg leading-relaxed mb-6">
-                Spécialistes des événements sur-mesure, nous personnalisons votre borne photo selon vos envies : choix des couleurs, intégration de votre logo ou nom, personnalisation des accessoires… Tout est possible pour une intégration parfaite à l'univers de votre événement !
+                Louer un photobooth lors de vos événements à Paris, c'est l'assurance de marquer les
+                esprits et d'apporter une touche d'originalité à votre image. Grâce à la
+                personnalisation sur mesure (habillage, accessoires, tirages photos), le photobooth
+                devient même le reflet de votre univers pour une intégration parfaite dans le décor de
+                votre soirée à thème !
               </p>
               <p className="text-gray-700 text-lg leading-relaxed">
-                Vous souhaitez un habillage aux couleurs de votre entreprise ? Un fond d'écran estampillé à votre effigie ? Des photos souvenirs avec votre logo ? Grâce à The Pix, donnez vie à toutes vos idées pour créer une borne photo à votre image.
+                Et si vos convives repartent avec des photos souvenirs pleines de folie et, en prime,
+                des goodies estampillés à votre effigie, soyez sûrs qu'ils ne sont pas prêts de vous
+                oublier ! Le photobooth contribue ainsi largement à votre notoriété, bien au-delà de
+                votre soirée.
               </p>
             </div>
           </section>
 
-          {/* Une équipe dédiée */}
+          {/* Équipe */}
           <section className="mb-16">
             <div className="bg-gray-50 p-8 rounded-2xl">
               <div className="flex items-center space-x-4 mb-6">
                 <div className="w-12 h-12 bg-red-500 rounded-xl flex items-center justify-center">
                   <Award className="w-6 h-6 text-white" />
                 </div>
-                <h2 className="text-3xl font-bold text-black">Une équipe dédiée pour un service 5 étoiles</h2>
+                <h2 className="text-3xl font-bold text-black">Une équipe d'experts à votre écoute</h2>
               </div>
               <p className="text-gray-700 text-lg leading-relaxed mb-6">
-                Chez The Pix, vous bénéficiez d'un service 5 étoiles de la première prise de contact à la fin de votre événement :
+                Chez The Pix, vous bénéficiez de l'accompagnement sur mesure d'une équipe d'experts
+                de A à Z pour vous aider à louer et installer votre photobooth facilement.
               </p>
-              <div className="grid md:grid-cols-2 gap-6">
-                <div className="bg-white p-6 rounded-xl">
-                  <ul className="space-y-3">
-                    <li className="flex items-center space-x-3">
-                      <Check className="w-5 h-5 text-green-500" />
-                      <span className="text-gray-700">Interlocuteur dédié pour répondre à toutes vos questions</span>
-                    </li>
-                    <li className="flex items-center space-x-3">
-                      <Check className="w-5 h-5 text-green-500" />
-                      <span className="text-gray-700">Conseils personnalisés pour choisir le photobooth idéal</span>
-                    </li>
-                    <li className="flex items-center space-x-3">
-                      <Check className="w-5 h-5 text-green-500" />
-                      <span className="text-gray-700">Livraison et installation clés en main</span>
-                    </li>
-                  </ul>
-                </div>
-                <div className="bg-white p-6 rounded-xl">
-                  <ul className="space-y-3">
-                    <li className="flex items-center space-x-3">
-                      <Check className="w-5 h-5 text-green-500" />
-                      <span className="text-gray-700">Assistance technique pendant toute la durée de l'événement</span>
-                    </li>
-                    <li className="flex items-center space-x-3">
-                      <Check className="w-5 h-5 text-green-500" />
-                      <span className="text-gray-700">Démontage rapide et restitution de la salle en l'état</span>
-                    </li>
-                  </ul>
-                </div>
-              </div>
-              <div className="mt-6 bg-white p-6 rounded-xl">
-                <p className="text-gray-700">
-                  Grâce à The Pix, profitez d'un service de location de photobooth ou borne photo haut de gamme pour un résultat à la hauteur de vos attentes, aussi bien pour un usage privé que professionnel. Contactez-nous dès maintenant pour louer une borne photo d'exception facile à utiliser à Paris 7 !
-                </p>
-              </div>
             </div>
           </section>
 
@@ -314,15 +312,18 @@ const Paris7Page: React.FC<Paris7PageProps> = ({ onBack, onQuoteRequest, onPhoto
                 <div className="w-12 h-12 bg-yellow-400 rounded-xl flex items-center justify-center">
                   <Star className="w-6 h-6 text-black" />
                 </div>
-                <h2 className="text-3xl font-bold text-black">Créez des souvenirs mémorables</h2>
+                <h2 className="text-3xl font-bold text-black">Prêt à faire sourire vos invités ?</h2>
               </div>
               <div className="bg-white p-6 rounded-xl">
-                <h3 className="font-bold text-black mb-4 text-xl">Prêt à transformer votre événement en une expérience inoubliable ?</h3>
+                <h3 className="font-bold text-black mb-4 text-xl">Réservez votre photobooth à Paris 8 dès maintenant</h3>
                 <p className="text-gray-700 mb-6">
-                  Réservez dès maintenant votre borne photo dans le 7ème arrondissement de Paris et créez des souvenirs exceptionnels pour vos invités.
+                  Pour louer un photobooth innovant et tendance au cœur de Paris, rendez-vous sur
+                  ThePix.fr ! Notre service de location sur mesure répondra à toutes vos attentes.
+                  Réservez dès maintenant votre photobooth à Paris 8 et faites de votre événement un
+                  moment inoubliable. Alors à vos cabines... prêts ? Souriez !
                 </p>
                 <div className="flex flex-col sm:flex-row gap-4">
-                  <button 
+                  <button
                     onClick={onQuoteRequest}
                     className="bg-yellow-400 text-black px-8 py-4 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
                   >
@@ -346,12 +347,12 @@ const Paris7Page: React.FC<Paris7PageProps> = ({ onBack, onQuoteRequest, onPhoto
           { label: 'Location photobooth Paris 4', onClick: onParis4Page },
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
-          { label: 'Location photobooth Paris 7', onClick: onBack },
-          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
+          { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onBack },
         ]}
       />
     </div>
   );
 };
 
-export default Paris7Page;
+export default Paris8Page;

--- a/src/components/PhotoboothDetailsPage.tsx
+++ b/src/components/PhotoboothDetailsPage.tsx
@@ -26,10 +26,11 @@ interface PhotoboothDetailsPageProps {
   onParis5Page?: () => void;
   onParis6Page?: () => void;
   onParis7Page?: () => void;
+  onParis8Page?: () => void;
   onQuoteRequest?: () => void;
 }
 
-const PhotoboothDetailsPage: React.FC<PhotoboothDetailsPageProps> = ({ onBack, onAIAnimations, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onQuoteRequest }) => {
+const PhotoboothDetailsPage: React.FC<PhotoboothDetailsPageProps> = ({ onBack, onAIAnimations, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onQuoteRequest }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -541,6 +542,7 @@ const PhotoboothDetailsPage: React.FC<PhotoboothDetailsPageProps> = ({ onBack, o
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>

--- a/src/components/PhotographerAIPage.tsx
+++ b/src/components/PhotographerAIPage.tsx
@@ -33,9 +33,10 @@ interface PhotographerAIPageProps {
   onParis5Page?: () => void;
   onParis6Page?: () => void;
   onParis7Page?: () => void;
+  onParis8Page?: () => void;
 }
 
-const PhotographerAIPage: React.FC<PhotographerAIPageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page }) => {
+const PhotographerAIPage: React.FC<PhotographerAIPageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -515,6 +516,7 @@ const PhotographerAIPage: React.FC<PhotographerAIPageProps> = ({ onBack, onQuote
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>

--- a/src/components/QuotePage.tsx
+++ b/src/components/QuotePage.tsx
@@ -24,9 +24,10 @@ interface QuotePageProps {
   onParis5Page?: () => void;
   onParis6Page?: () => void;
   onParis7Page?: () => void;
+  onParis8Page?: () => void;
 }
 
-const QuotePage: React.FC<QuotePageProps> = ({ onBack, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page }) => {
+const QuotePage: React.FC<QuotePageProps> = ({ onBack, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page }) => {
   const [currentStep, setCurrentStep] = useState(1);
   const [formData, setFormData] = useState({
     clientType: '', // 'enterprise' or 'wedding'
@@ -550,6 +551,7 @@ const QuotePage: React.FC<QuotePageProps> = ({ onBack, onSEOPage, onParis1Page, 
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>

--- a/src/components/SEOPage.tsx
+++ b/src/components/SEOPage.tsx
@@ -29,9 +29,10 @@ interface SEOPageProps {
   onParis5Page?: () => void;
   onParis6Page?: () => void;
   onParis7Page?: () => void;
+  onParis8Page?: () => void;
 }
 
-const SEOPage: React.FC<SEOPageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page }) => {
+const SEOPage: React.FC<SEOPageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -488,6 +489,7 @@ const SEOPage: React.FC<SEOPageProps> = ({ onBack, onQuoteRequest, onPhotoboothD
           { label: 'Location photobooth Paris 5', onClick: onParis5Page },
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
         ]}
       />
     </div>


### PR DESCRIPTION
## Summary
- enrich Paris 8 photobooth landing with new editorial sections, booking tips, social sharing, branding benefits and call to action

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8137c33488331a12f6f42372bd9a4