### PR TITLE
Add Paris 9 photobooth page and update navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import Paris5Page from './components/Paris5Page';
 import Paris6Page from './components/Paris6Page';
 import Paris7Page from './components/Paris7Page';
 import Paris8Page from './components/Paris8Page';
+import Paris9Page from './components/Paris9Page';
 import { 
   Camera,
   Sparkles,
@@ -51,6 +52,7 @@ function App() {
   const [showParis6Page, setShowParis6Page] = useState(false);
   const [showParis7Page, setShowParis7Page] = useState(false);
   const [showParis8Page, setShowParis8Page] = useState(false);
+  const [showParis9Page, setShowParis9Page] = useState(false);
   const [previousPage, setPreviousPage] = useState<string>('home');
 
   // Fonction pour remettre le scroll en haut
@@ -61,7 +63,7 @@ function App() {
   // Effet pour remettre le scroll en haut quand on change de page
   useEffect(() => {
     scrollToTop();
-  }, [showQuotePage, showPhotoboothDetails, showAIAnimations, showDemoRequest, showSEOPage, showPhotographerAI, showParis1Page, showParis2Page, showParis3Page, showParis4Page, showParis5Page, showParis6Page, showParis7Page, showParis8Page]);
+  }, [showQuotePage, showPhotoboothDetails, showAIAnimations, showDemoRequest, showSEOPage, showPhotographerAI, showParis1Page, showParis2Page, showParis3Page, showParis4Page, showParis5Page, showParis6Page, showParis7Page, showParis8Page, showParis9Page]);
 
   // Fonction pour gérer le retour depuis la page de devis
   const handleQuotePageBack = () => {
@@ -97,6 +99,9 @@ function App() {
         break;
       case 'paris8':
         setShowParis8Page(true);
+        break;
+      case 'paris9':
+        setShowParis9Page(true);
         break;
       default:
         // Rester sur la page principale
@@ -149,6 +154,10 @@ function App() {
         setShowQuotePage(false);
         setShowParis8Page(true);
       }}
+      onParis9Page={() => {
+        setShowQuotePage(false);
+        setShowParis9Page(true);
+      }}
     />;
   }
 
@@ -194,6 +203,10 @@ function App() {
       onParis8Page={() => {
         setShowPhotoboothDetails(false);
         setShowParis8Page(true);
+      }}
+      onParis9Page={() => {
+        setShowPhotoboothDetails(false);
+        setShowParis9Page(true);
       }}
       onQuoteRequest={() => {
         setShowPhotoboothDetails(false);
@@ -249,6 +262,10 @@ function App() {
         setShowAIAnimations(false);
         setShowParis8Page(true);
       }}
+      onParis9Page={() => {
+        setShowAIAnimations(false);
+        setShowParis9Page(true);
+      }}
       onQuoteRequest={() => {
         setShowAIAnimations(false);
         openQuotePage('aiAnimations');
@@ -294,6 +311,10 @@ function App() {
       onParis8Page={() => {
         setShowDemoRequest(false);
         setShowParis8Page(true);
+      }}
+      onParis9Page={() => {
+        setShowDemoRequest(false);
+        setShowParis9Page(true);
       }}
       onQuoteRequest={() => {
         setShowDemoRequest(false);
@@ -349,6 +370,10 @@ function App() {
         setShowSEOPage(false);
         setShowParis8Page(true);
       }}
+      onParis9Page={() => {
+        setShowSEOPage(false);
+        setShowParis9Page(true);
+      }}
     />;
   }
 
@@ -403,6 +428,10 @@ function App() {
         setShowPhotographerAI(false);
         setShowParis8Page(true);
       }}
+      onParis9Page={() => {
+        setShowPhotographerAI(false);
+        setShowParis9Page(true);
+      }}
     />;
   }
 
@@ -452,6 +481,10 @@ function App() {
       onParis8Page={() => {
         setShowParis1Page(false);
         setShowParis8Page(true);
+      }}
+      onParis9Page={() => {
+        setShowParis1Page(false);
+        setShowParis9Page(true);
       }}
     />;
   }
@@ -503,6 +536,10 @@ function App() {
         setShowParis2Page(false);
         setShowParis8Page(true);
       }}
+      onParis9Page={() => {
+        setShowParis2Page(false);
+        setShowParis9Page(true);
+      }}
     />;
   }
 
@@ -552,6 +589,10 @@ function App() {
       onParis8Page={() => {
         setShowParis3Page(false);
         setShowParis8Page(true);
+      }}
+      onParis9Page={() => {
+        setShowParis3Page(false);
+        setShowParis9Page(true);
       }}
     />;
   }
@@ -603,6 +644,10 @@ function App() {
         setShowParis4Page(false);
         setShowParis8Page(true);
       }}
+      onParis9Page={() => {
+        setShowParis4Page(false);
+        setShowParis9Page(true);
+      }}
     />;
   }
 
@@ -652,6 +697,10 @@ function App() {
       onParis8Page={() => {
         setShowParis5Page(false);
         setShowParis8Page(true);
+      }}
+      onParis9Page={() => {
+        setShowParis5Page(false);
+        setShowParis9Page(true);
       }}
     />;
   }
@@ -703,6 +752,10 @@ function App() {
         setShowParis6Page(false);
         setShowParis8Page(true);
       }}
+      onParis9Page={() => {
+        setShowParis6Page(false);
+        setShowParis9Page(true);
+      }}
     />;
   }
 
@@ -753,6 +806,10 @@ function App() {
         setShowParis7Page(false);
         setShowParis8Page(true);
       }}
+      onParis9Page={() => {
+        setShowParis7Page(false);
+        setShowParis9Page(true);
+      }}
     />;
   }
 
@@ -802,6 +859,64 @@ function App() {
       onParis7Page={() => {
         setShowParis8Page(false);
         setShowParis7Page(true);
+      }}
+      onParis9Page={() => {
+        setShowParis8Page(false);
+        setShowParis9Page(true);
+      }}
+    />;
+  }
+
+  if (showParis9Page) {
+    return <Paris9Page
+      onBack={() => setShowParis9Page(false)}
+      onQuoteRequest={() => {
+        setShowParis9Page(false);
+        openQuotePage('paris9');
+      }}
+      onPhotoboothDetails={() => {
+        setShowParis9Page(false);
+        setShowPhotoboothDetails(true);
+      }}
+      onAIAnimations={() => {
+        setShowParis9Page(false);
+        setShowAIAnimations(true);
+      }}
+      onSEOPage={() => {
+        setShowParis9Page(false);
+        setShowSEOPage(true);
+      }}
+      onParis1Page={() => {
+        setShowParis9Page(false);
+        setShowParis1Page(true);
+      }}
+      onParis2Page={() => {
+        setShowParis9Page(false);
+        setShowParis2Page(true);
+      }}
+      onParis3Page={() => {
+        setShowParis9Page(false);
+        setShowParis3Page(true);
+      }}
+      onParis4Page={() => {
+        setShowParis9Page(false);
+        setShowParis4Page(true);
+      }}
+      onParis5Page={() => {
+        setShowParis9Page(false);
+        setShowParis5Page(true);
+      }}
+      onParis6Page={() => {
+        setShowParis9Page(false);
+        setShowParis6Page(true);
+      }}
+      onParis7Page={() => {
+        setShowParis9Page(false);
+        setShowParis7Page(true);
+      }}
+      onParis8Page={() => {
+        setShowParis9Page(false);
+        setShowParis8Page(true);
       }}
     />;
   }
@@ -1623,6 +1738,12 @@ function App() {
                   className="block text-gray-600 hover:text-yellow-500 transition-colors text-left"
                 >
                   Location photobooth Paris 8
+                </button>
+                <button
+                  onClick={() => setShowParis9Page(true)}
+                  className="block text-gray-600 hover:text-yellow-500 transition-colors text-left"
+                >
+                  Location photobooth Paris 9
                 </button>
               </div>
             </div>

--- a/src/components/AIAnimationsPage.tsx
+++ b/src/components/AIAnimationsPage.tsx
@@ -37,9 +37,10 @@ interface AIAnimationsPageProps {
   onParis7Page?: () => void;
   onParis8Page?: () => void;
   onQuoteRequest?: () => void;
+  onParis9Page?: () => void;
 }
 
-const AIAnimationsPage: React.FC<AIAnimationsPageProps> = ({ onBack, onDemoRequest, onPhotoboothDetails, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onQuoteRequest }) => {
+const AIAnimationsPage: React.FC<AIAnimationsPageProps> = ({ onBack, onDemoRequest, onPhotoboothDetails, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onQuoteRequest, onParis9Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -565,6 +566,7 @@ const AIAnimationsPage: React.FC<AIAnimationsPageProps> = ({ onBack, onDemoReque
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
           { label: 'Location photobooth Paris 8', onClick: onParis8Page },
+          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
         ]}
       />
     </div>

--- a/src/components/DemoRequestPage.tsx
+++ b/src/components/DemoRequestPage.tsx
@@ -29,9 +29,10 @@ interface DemoRequestPageProps {
   onParis7Page?: () => void;
   onParis8Page?: () => void;
   onQuoteRequest?: () => void;
+  onParis9Page?: () => void;
 }
 
-const DemoRequestPage: React.FC<DemoRequestPageProps> = ({ onBack, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onQuoteRequest }) => {
+const DemoRequestPage: React.FC<DemoRequestPageProps> = ({ onBack, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onQuoteRequest, onParis9Page }) => {
   const [currentStep, setCurrentStep] = useState(1);
   const [formData, setFormData] = useState({
     demoType: '', // 'live' or 'video'
@@ -475,6 +476,7 @@ const DemoRequestPage: React.FC<DemoRequestPageProps> = ({ onBack, onSEOPage, on
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
           { label: 'Location photobooth Paris 8', onClick: onParis8Page },
+          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
         ]}
       />
     </div>

--- a/src/components/Paris1Page.tsx
+++ b/src/components/Paris1Page.tsx
@@ -26,9 +26,10 @@ interface Paris1PageProps {
   onParis6Page?: () => void;
   onParis7Page?: () => void;
   onParis8Page?: () => void;
+  onParis9Page?: () => void;
 }
 
-const Paris1Page: React.FC<Paris1PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page }) => {
+const Paris1Page: React.FC<Paris1PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onParis9Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -328,6 +329,7 @@ const Paris1Page: React.FC<Paris1PageProps> = ({ onBack, onQuoteRequest, onPhoto
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
           { label: 'Location photobooth Paris 8', onClick: onParis8Page },
+          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
         ]}
       />
     </div>

--- a/src/components/Paris2Page.tsx
+++ b/src/components/Paris2Page.tsx
@@ -23,9 +23,10 @@ interface Paris2PageProps {
   onParis6Page?: () => void;
   onParis7Page?: () => void;
   onParis8Page?: () => void;
+  onParis9Page?: () => void;
 }
 
-const Paris2Page: React.FC<Paris2PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page }) => {
+const Paris2Page: React.FC<Paris2PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onParis9Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -285,6 +286,7 @@ const Paris2Page: React.FC<Paris2PageProps> = ({ onBack, onQuoteRequest, onPhoto
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
           { label: 'Location photobooth Paris 8', onClick: onParis8Page },
+          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
         ]}
       />
     </div>

--- a/src/components/Paris3Page.tsx
+++ b/src/components/Paris3Page.tsx
@@ -26,9 +26,10 @@ interface Paris3PageProps {
   onParis6Page?: () => void;
   onParis7Page?: () => void;
   onParis8Page?: () => void;
+  onParis9Page?: () => void;
 }
 
-const Paris3Page: React.FC<Paris3PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page }) => {
+const Paris3Page: React.FC<Paris3PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onParis9Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -273,6 +274,7 @@ const Paris3Page: React.FC<Paris3PageProps> = ({ onBack, onQuoteRequest, onPhoto
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
           { label: 'Location photobooth Paris 8', onClick: onParis8Page },
+          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
         ]}
       />
     </div>

--- a/src/components/Paris4Page.tsx
+++ b/src/components/Paris4Page.tsx
@@ -26,9 +26,10 @@ interface Paris4PageProps {
   onParis6Page?: () => void;
   onParis7Page?: () => void;
   onParis8Page?: () => void;
+  onParis9Page?: () => void;
 }
 
-const Paris4Page: React.FC<Paris4PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page }) => {
+const Paris4Page: React.FC<Paris4PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onParis9Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -275,6 +276,7 @@ const Paris4Page: React.FC<Paris4PageProps> = ({ onBack, onQuoteRequest, onPhoto
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
           { label: 'Location photobooth Paris 8', onClick: onParis8Page },
+          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
         ]}
       />
     </div>

--- a/src/components/Paris5Page.tsx
+++ b/src/components/Paris5Page.tsx
@@ -27,9 +27,10 @@ interface Paris5PageProps {
   onParis6Page?: () => void;
   onParis7Page?: () => void;
   onParis8Page?: () => void;
+  onParis9Page?: () => void;
 }
 
-const Paris5Page: React.FC<Paris5PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis6Page, onParis7Page, onParis8Page }) => {
+const Paris5Page: React.FC<Paris5PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis6Page, onParis7Page, onParis8Page, onParis9Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -267,6 +268,7 @@ const Paris5Page: React.FC<Paris5PageProps> = ({ onBack, onQuoteRequest, onPhoto
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
           { label: 'Location photobooth Paris 8', onClick: onParis8Page },
+          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
         ]}
       />
     </div>

--- a/src/components/Paris6Page.tsx
+++ b/src/components/Paris6Page.tsx
@@ -29,9 +29,10 @@ interface Paris6PageProps {
   onParis5Page?: () => void;
   onParis7Page?: () => void;
   onParis8Page?: () => void;
+  onParis9Page?: () => void;
 }
 
-const Paris6Page: React.FC<Paris6PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis7Page, onParis8Page }) => {
+const Paris6Page: React.FC<Paris6PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis7Page, onParis8Page, onParis9Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -322,6 +323,7 @@ const Paris6Page: React.FC<Paris6PageProps> = ({ onBack, onQuoteRequest, onPhoto
           { label: 'Location photobooth Paris 6', onClick: onBack },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
           { label: 'Location photobooth Paris 8', onClick: onParis8Page },
+          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
         ]}
       />
     </div>

--- a/src/components/Paris7Page.tsx
+++ b/src/components/Paris7Page.tsx
@@ -28,9 +28,10 @@ interface Paris7PageProps {
   onParis5Page?: () => void;
   onParis6Page?: () => void;
   onParis8Page?: () => void;
+  onParis9Page?: () => void;
 }
 
-const Paris7Page: React.FC<Paris7PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis8Page }) => {
+const Paris7Page: React.FC<Paris7PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis8Page, onParis9Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -348,6 +349,7 @@ const Paris7Page: React.FC<Paris7PageProps> = ({ onBack, onQuoteRequest, onPhoto
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onBack },
           { label: 'Location photobooth Paris 8', onClick: onParis8Page },
+          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
         ]}
       />
     </div>

--- a/src/components/Paris8Page.tsx
+++ b/src/components/Paris8Page.tsx
@@ -28,6 +28,7 @@ interface Paris8PageProps {
   onParis5Page?: () => void;
   onParis6Page?: () => void;
   onParis7Page?: () => void;
+  onParis9Page?: () => void;
 }
 
 const Paris8Page: React.FC<Paris8PageProps> = ({
@@ -43,6 +44,7 @@ const Paris8Page: React.FC<Paris8PageProps> = ({
   onParis5Page,
   onParis6Page,
   onParis7Page,
+  onParis9Page,
 }) => {
   return (
     <div className="min-h-screen bg-white">
@@ -346,6 +348,7 @@ const Paris8Page: React.FC<Paris8PageProps> = ({
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
           { label: 'Location photobooth Paris 8', onClick: onBack },
+          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
         ]}
       />
     </div>

--- a/src/components/Paris9Page.tsx
+++ b/src/components/Paris9Page.tsx
@@ -1,0 +1,296 @@
+import React from 'react';
+import {
+  ArrowLeft,
+  Camera,
+  Heart,
+  Sparkles,
+  Share2,
+  Settings,
+  Eye,
+  Award,
+  Star,
+  Monitor,
+} from 'lucide-react';
+import HomeSectionLink from './HomeSectionLink';
+import Footer from './Footer';
+
+interface Paris9PageProps {
+  onBack: () => void;
+  onQuoteRequest?: () => void;
+  onPhotoboothDetails?: () => void;
+  onAIAnimations?: () => void;
+  onSEOPage?: () => void;
+  onParis1Page?: () => void;
+  onParis2Page?: () => void;
+  onParis3Page?: () => void;
+  onParis4Page?: () => void;
+  onParis5Page?: () => void;
+  onParis6Page?: () => void;
+  onParis7Page?: () => void;
+  onParis8Page?: () => void;
+}
+
+const Paris9Page: React.FC<Paris9PageProps> = ({
+  onBack,
+  onQuoteRequest,
+  onPhotoboothDetails,
+  onAIAnimations,
+  onSEOPage,
+  onParis1Page,
+  onParis2Page,
+  onParis3Page,
+  onParis4Page,
+  onParis5Page,
+  onParis6Page,
+  onParis7Page,
+  onParis8Page,
+}) => {
+  return (
+    <div className="min-h-screen bg-white">
+      {/* Header */}
+      <header className="fixed top-0 left-0 right-0 bg-white/95 backdrop-blur-sm z-50 border-b border-gray-100">
+        <div className="max-w-7xl mx-auto px-6">
+          <div className="flex items-center justify-between h-20">
+            <div className="flex items-center space-x-3">
+              <div className="w-10 h-10 bg-yellow-400 rounded-full flex items-center justify-center">
+                <Camera className="w-6 h-6 text-black" />
+              </div>
+              <span className="text-2xl font-bold text-black">BoostPix</span>
+            </div>
+
+            <nav className="hidden lg:flex items-center space-x-8">
+              <button
+                onClick={onBack}
+                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
+              >
+                Accueil
+              </button>
+              <button
+                onClick={onPhotoboothDetails}
+                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
+              >
+                Photobooth sur mesure
+              </button>
+              <HomeSectionLink label="Événements Privés" targetId="mariages" onBack={onBack} />
+              <button
+                onClick={onAIAnimations}
+                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
+              >
+                Animations IA
+              </button>
+              <HomeSectionLink label="Galerie" targetId="galerie" onBack={onBack} />
+              <button
+                onClick={onQuoteRequest}
+                className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
+              >
+                Devis Gratuit
+              </button>
+            </nav>
+
+            <button
+              onClick={onBack}
+              className="lg:hidden flex items-center space-x-2 text-gray-600 hover:text-gray-800 transition-colors"
+            >
+              <ArrowLeft className="w-5 h-5" />
+              <span>Retour</span>
+            </button>
+          </div>
+        </div>
+      </header>
+
+      {/* Hero Section */}
+      <section className="py-20 bg-gray-50 mt-20">
+        <div className="max-w-7xl mx-auto px-6">
+          <div className="text-center mb-16">
+            <h1 className="text-4xl lg:text-6xl font-bold text-black mb-6 leading-tight">
+              Louer un photobooth dans le
+              <span className="text-yellow-400 relative">{' '}9ème arrondissement de Paris<div className="absolute -bottom-2 left-0 w-full h-3 bg-yellow-400 -z-10"></div></span>
+            </h1>
+          </div>
+        </div>
+      </section>
+
+      {/* Main Content */}
+      <div className="max-w-4xl mx-auto px-6 py-16">
+        <article className="prose prose-lg max-w-none">
+          {/* Introduction */}
+          <section className="mb-16">
+            <div className="bg-white p-8 rounded-2xl shadow-sm border border-gray-100">
+              <div className="flex items-center space-x-4 mb-6">
+                <div className="w-12 h-12 bg-yellow-400 rounded-xl flex items-center justify-center">
+                  <Heart className="w-6 h-6 text-black" />
+                </div>
+                <h2 className="text-3xl font-bold text-black">Location photobooth Paris 9</h2>
+              </div>
+              <p className="text-gray-700 text-lg leading-relaxed mb-6">
+                Avec ses grandes avenues haussmanniennes et ses passages couverts secrets, le 9ème arrondissement de Paris est un terrain de jeu idéal pour tout type d’événement privé ou professionnel. Qu’il s’agisse d’un lancement de produit au cœur du Quartier de l’Opéra ou d’une réception intimiste dans les ruelles de la Nouvelle Athènes, cet arrondissement vibrant offre un cadre propice pour créer des moments inoubliables. C’est dans ce décor vivant que The Pix vous propose de louer un photobooth dernier cri pour sublimer vos rassemblements.
+              </p>
+            </div>
+          </section>
+
+          {/* Tendance */}
+          <section className="mb-16">
+            <div className="bg-gradient-to-br from-pink-50 to-yellow-50 p-8 rounded-2xl">
+              <div className="flex items-center space-x-4 mb-6">
+                <div className="w-12 h-12 bg-pink-500 rounded-xl flex items-center justify-center">
+                  <Sparkles className="w-6 h-6 text-white" />
+                </div>
+                <h2 className="text-3xl font-bold text-black">Le photobooth : la tendance du moment à Paris</h2>
+              </div>
+              <p className="text-gray-700 text-lg leading-relaxed mb-6">
+                Ces dernières années, de plus en plus d’organisateurs optent pour la location d’un photobooth lors de leurs événements, car c’est devenu une animation incontournable, plébiscitée autant par les jeunes que par les moins jeunes. Qu’il s’agisse de mariages romantiques Place Saint-Georges, de soirées d’entreprise au Palais Garnier ou encore d’anniversaires festifs aux abords de Pigalle, le photobooth apporte une touche d’originalité et de convivialité à tout type de réception, dans une ambiance décontractée.
+              </p>
+              <p className="text-gray-700 text-lg leading-relaxed">
+                Vos invités pourront se prendre en photo dans notre cabine photo dernier cri, puis repartir instantanément avec leurs photos souvenirs. L’occasion rêvée de créer une ambiance festive lors de votre événement à Paris 9 ! Le photobooth renforce les liens et donne lieu à des moments de partage spontanés entre vos convives.
+              </p>
+            </div>
+          </section>
+
+          {/* Technologies */}
+          <section className="mb-16">
+            <div className="bg-white p-8 rounded-2xl shadow-sm border border-gray-100">
+              <div className="flex items-center space-x-4 mb-6">
+                <div className="w-12 h-12 bg-blue-500 rounded-xl flex items-center justify-center">
+                  <Settings className="w-6 h-6 text-white" />
+                </div>
+                <h2 className="text-3xl font-bold text-black">Une cabine photo intégrant technologies de pointe et design moderne</h2>
+              </div>
+              <ul className="text-gray-700 text-lg leading-relaxed list-disc pl-6 space-y-2 mb-6">
+                <li>Appareil photo professionnel pour des clichés haute définition</li>
+                <li>Écran tactile dernier cri pour personnaliser facilement vos images</li>
+                <li>Impression instantanée de vos photos souvenirs</li>
+                <li>Partage immédiat sur les réseaux sociaux</li>
+                <li>Grand choix d’accessoires drôles et de déguisements</li>
+                <li>Fonds d’écran personnalisés pour sublimer vos photos</li>
+              </ul>
+              <p className="text-gray-700 text-lg leading-relaxed">
+                Nos photobooths garantissent une animation mémorable et décontractée lors de vos événements à Paris 9 pour le plus grand bonheur de vos convives. Vos invités repartiront avec des photos uniques et des vidéos souvenirs pleines de surprises !
+              </p>
+            </div>
+          </section>
+
+          {/* Réservation */}
+          <section className="mb-16">
+            <div className="bg-gray-50 p-8 rounded-2xl">
+              <div className="flex items-center space-x-4 mb-6">
+                <div className="w-12 h-12 bg-indigo-500 rounded-xl flex items-center justify-center">
+                  <Monitor className="w-6 h-6 text-white" />
+                </div>
+                <h2 className="text-3xl font-bold text-black">Réservez votre photobooth en quelques clics</h2>
+              </div>
+              <p className="text-gray-700 text-lg leading-relaxed">
+                Grâce à notre site web accessible 24h/24 et 7j/7, réserver un photobooth à Paris se fait en toute simplicité. Indiquez simplement la date, le lieu de votre réception et vos options préférées. Notre équipe gère ensuite l’ensemble de la logistique de A à Z afin que vous puissiez vous concentrer pleinement sur l’accueil de vos invités.
+              </p>
+              <p className="text-gray-700 text-lg leading-relaxed mt-6">
+                Le jour J, profitez à 100% de chaque instant pendant que nous nous occupons entièrement du photobooth. Notre personnel reste également à votre écoute pour répondre à toutes vos questions en amont comme pendant l’événement.
+              </p>
+            </div>
+          </section>
+
+          {/* Partage */}
+          <section className="mb-16">
+            <div className="bg-gradient-to-br from-purple-50 to-blue-50 p-8 rounded-2xl">
+              <div className="flex items-center space-x-4 mb-6">
+                <div className="w-12 h-12 bg-purple-500 rounded-xl flex items-center justify-center">
+                  <Share2 className="w-6 h-6 text-white" />
+                </div>
+                <h2 className="text-3xl font-bold text-black">Partagez vos meilleurs moments sur les réseaux sociaux</h2>
+              </div>
+              <p className="text-gray-700 text-lg leading-relaxed">
+                La cabine photo permet à vos invités de partager leurs plus belles photos sur les réseaux sociaux et de donner une visibilité accrue à votre événement au-delà de Paris 9, notamment via la création d’un hashtag dédié. C’est aussi une façon originale de faire vivre vos meilleurs moments ensemble et d’entretenir le souvenir de votre soirée après celle-ci !
+              </p>
+            </div>
+          </section>
+
+          {/* Image de marque */}
+          <section className="mb-16">
+            <div className="bg-white p-8 rounded-2xl shadow-sm border border-gray-100">
+              <div className="flex items-center space-x-4 mb-6">
+                <div className="w-12 h-12 bg-green-500 rounded-xl flex items-center justify-center">
+                  <Eye className="w-6 h-6 text-white" />
+                </div>
+                <h2 className="text-3xl font-bold text-black">Un accessoire tendance pour une image de marque branchée</h2>
+              </div>
+              <p className="text-gray-700 text-lg leading-relaxed mb-6">
+                Louer un photobooth lors de vos événements à Paris, c’est l’assurance de marquer les esprits et d’apporter une touche d’originalité à votre image. Grâce à la personnalisation de la cabine et des accessoires, le photobooth reflète parfaitement l’esprit de votre soirée et devient le prolongement naturel de votre univers pour une intégration harmonieuse dans l’ambiance de votre réception.
+              </p>
+              <p className="text-gray-700 text-lg leading-relaxed">
+                Vos invités sont également susceptibles de partager leurs photos souvenirs insolites sur les réseaux sociaux, contribuant ainsi à accroître votre notoriété de manière positive et durable, notamment auprès des jeunes générations friandes de ce genre d’animations !
+              </p>
+            </div>
+          </section>
+
+          {/* Équipe */}
+          <section className="mb-16">
+            <div className="bg-gray-50 p-8 rounded-2xl">
+              <div className="flex items-center space-x-4 mb-6">
+                <div className="w-12 h-12 bg-red-500 rounded-xl flex items-center justify-center">
+                  <Award className="w-6 h-6 text-white" />
+                </div>
+                <h2 className="text-3xl font-bold text-black">Une équipe d’experts à votre service</h2>
+              </div>
+              <p className="text-gray-700 text-lg leading-relaxed mb-6">
+                Chez The Pix, vous bénéficiez de l’accompagnement sur mesure d’une équipe d’experts passionnés, de la prise de contact à la fin de votre réception :
+              </p>
+              <ul className="text-gray-700 text-lg leading-relaxed list-disc pl-6 space-y-2">
+                <li>Interlocuteur dédié pour répondre à toutes vos questions</li>
+                <li>Conseils avisés pour sélectionner le photobooth idéal</li>
+                <li>Livraison et installation clés en main</li>
+                <li>Assistance technique de pointe durant toute la soirée</li>
+                <li>Démontage discret et remise en état des lieux</li>
+              </ul>
+            </div>
+          </section>
+
+          {/* Conclusion */}
+          <section className="mb-16">
+            <div className="bg-yellow-50 border border-yellow-200 p-8 rounded-2xl">
+              <div className="flex items-center space-x-4 mb-6">
+                <div className="w-12 h-12 bg-yellow-400 rounded-xl flex items-center justify-center">
+                  <Star className="w-6 h-6 text-black" />
+                </div>
+                <h2 className="text-3xl font-bold text-black">Prêt à faire sourire vos invités ?</h2>
+              </div>
+              <div className="bg-white p-6 rounded-xl">
+                <h3 className="font-bold text-black mb-4 text-xl">
+                  Pour louer un photobooth innovant et tendance au cœur de Paris, ne cherchez plus !
+                </h3>
+                <p className="text-gray-700 mb-6">
+                  Grâce à notre service sur mesure, nous créons avec vous les conditions d’une expérience fun et interactive pour vos convives. Contactez-nous vite !
+                </p>
+                <div className="flex flex-col sm:flex-row gap-4">
+                  <button
+                    onClick={onQuoteRequest}
+                    className="bg-yellow-400 text-black px-8 py-4 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
+                  >
+                    Demander un devis
+                  </button>
+                </div>
+              </div>
+            </div>
+          </section>
+        </article>
+      </div>
+
+      {/* Footer */}
+      <Footer
+        onSEOPage={onSEOPage}
+        onPhotoboothDetails={onPhotoboothDetails}
+        arrondissementLinks={[
+          { label: 'Location photobooth Paris 1', onClick: onParis1Page },
+          { label: 'Location photobooth Paris 2', onClick: onParis2Page },
+          { label: 'Location photobooth Paris 3', onClick: onParis3Page },
+          { label: 'Location photobooth Paris 4', onClick: onParis4Page },
+          { label: 'Location photobooth Paris 5', onClick: onParis5Page },
+          { label: 'Location photobooth Paris 6', onClick: onParis6Page },
+          { label: 'Location photobooth Paris 7', onClick: onParis7Page },
+          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
+          { label: 'Location photobooth Paris 9', onClick: onBack },
+        ]}
+      />
+    </div>
+  );
+};
+
+export default Paris9Page;
+

--- a/src/components/PhotoboothDetailsPage.tsx
+++ b/src/components/PhotoboothDetailsPage.tsx
@@ -28,9 +28,10 @@ interface PhotoboothDetailsPageProps {
   onParis7Page?: () => void;
   onParis8Page?: () => void;
   onQuoteRequest?: () => void;
+  onParis9Page?: () => void;
 }
 
-const PhotoboothDetailsPage: React.FC<PhotoboothDetailsPageProps> = ({ onBack, onAIAnimations, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onQuoteRequest }) => {
+const PhotoboothDetailsPage: React.FC<PhotoboothDetailsPageProps> = ({ onBack, onAIAnimations, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onQuoteRequest, onParis9Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -543,6 +544,7 @@ const PhotoboothDetailsPage: React.FC<PhotoboothDetailsPageProps> = ({ onBack, o
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
           { label: 'Location photobooth Paris 8', onClick: onParis8Page },
+          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
         ]}
       />
     </div>

--- a/src/components/PhotographerAIPage.tsx
+++ b/src/components/PhotographerAIPage.tsx
@@ -34,9 +34,10 @@ interface PhotographerAIPageProps {
   onParis6Page?: () => void;
   onParis7Page?: () => void;
   onParis8Page?: () => void;
+  onParis9Page?: () => void;
 }
 
-const PhotographerAIPage: React.FC<PhotographerAIPageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page }) => {
+const PhotographerAIPage: React.FC<PhotographerAIPageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onParis9Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -517,6 +518,7 @@ const PhotographerAIPage: React.FC<PhotographerAIPageProps> = ({ onBack, onQuote
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
           { label: 'Location photobooth Paris 8', onClick: onParis8Page },
+          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
         ]}
       />
     </div>

--- a/src/components/QuotePage.tsx
+++ b/src/components/QuotePage.tsx
@@ -25,9 +25,10 @@ interface QuotePageProps {
   onParis6Page?: () => void;
   onParis7Page?: () => void;
   onParis8Page?: () => void;
+  onParis9Page?: () => void;
 }
 
-const QuotePage: React.FC<QuotePageProps> = ({ onBack, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page }) => {
+const QuotePage: React.FC<QuotePageProps> = ({ onBack, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onParis9Page }) => {
   const [currentStep, setCurrentStep] = useState(1);
   const [formData, setFormData] = useState({
     clientType: '', // 'enterprise' or 'wedding'
@@ -552,6 +553,7 @@ const QuotePage: React.FC<QuotePageProps> = ({ onBack, onSEOPage, onParis1Page, 
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
           { label: 'Location photobooth Paris 8', onClick: onParis8Page },
+          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
         ]}
       />
     </div>

--- a/src/components/SEOPage.tsx
+++ b/src/components/SEOPage.tsx
@@ -30,9 +30,10 @@ interface SEOPageProps {
   onParis6Page?: () => void;
   onParis7Page?: () => void;
   onParis8Page?: () => void;
+  onParis9Page?: () => void;
 }
 
-const SEOPage: React.FC<SEOPageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page }) => {
+const SEOPage: React.FC<SEOPageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onParis9Page }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -490,6 +491,7 @@ const SEOPage: React.FC<SEOPageProps> = ({ onBack, onQuoteRequest, onPhotoboothD
           { label: 'Location photobooth Paris 6', onClick: onParis6Page },
           { label: 'Location photobooth Paris 7', onClick: onParis7Page },
           { label: 'Location photobooth Paris 8', onClick: onParis8Page },
+          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
         ]}
       />
     </div>


### PR DESCRIPTION
## Summary
- add dedicated Paris 9 page with booking, features and sharing info
- wire Paris 9 into app navigation and footers

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1d7222dec83319032de6f2ce67e6a