### PR TITLE
feat: centralize arrondissement navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -192,28 +192,57 @@ function App() {
     setShowQuotePage(true);
   };
 
-  const arrondissementLinks = [
-    { label: 'Location photobooth Paris 1', onClick: () => setShowParis1Page(true) },
-    { label: 'Location photobooth Paris 2', onClick: () => setShowParis2Page(true) },
-    { label: 'Location photobooth Paris 3', onClick: () => setShowParis3Page(true) },
-    { label: 'Location photobooth Paris 4', onClick: () => setShowParis4Page(true) },
-    { label: 'Location photobooth Paris 5', onClick: () => setShowParis5Page(true) },
-    { label: 'Location photobooth Paris 6', onClick: () => setShowParis6Page(true) },
-    { label: 'Location photobooth Paris 7', onClick: () => setShowParis7Page(true) },
-    { label: 'Location photobooth Paris 8', onClick: () => setShowParis8Page(true) },
-    { label: 'Location photobooth Paris 9', onClick: () => setShowParis9Page(true) },
-    { label: 'Location photobooth Paris 10', onClick: () => setShowParis10Page(true) },
-    { label: 'Location photobooth Paris 11', onClick: () => setShowParis11Page(true) },
-    { label: 'Location photobooth Paris 12', onClick: () => setShowParis12Page(true) },
-    { label: 'Location photobooth Paris 13', onClick: () => setShowParis13Page(true) },
-    { label: 'Location photobooth Paris 14', onClick: () => setShowParis14Page(true) },
-    { label: 'Location photobooth Paris 15', onClick: () => setShowParis15Page(true) },
-    { label: 'Location photobooth Paris 16', onClick: () => setShowParis16Page(true) },
-    { label: 'Location photobooth Paris 17', onClick: () => setShowParis17Page(true) },
-    { label: 'Location photobooth Paris 18', onClick: () => setShowParis18Page(true) },
-    { label: 'Location photobooth Paris 19', onClick: () => setShowParis19Page(true) },
-    { label: 'Location photobooth Paris 20', onClick: () => setShowParis20Page(true) },
-  ];
+  const goToParisPage = (n: number) => {
+    setShowQuotePage(false);
+    setShowPhotoboothDetails(false);
+    setShowAIAnimations(false);
+    setShowDemoRequest(false);
+    setShowSEOPage(false);
+    setShowPhotographerAI(false);
+    setShowParis1Page(false);
+    setShowParis2Page(false);
+    setShowParis3Page(false);
+    setShowParis4Page(false);
+    setShowParis5Page(false);
+    setShowParis6Page(false);
+    setShowParis7Page(false);
+    setShowParis8Page(false);
+    setShowParis9Page(false);
+    setShowParis10Page(false);
+    setShowParis11Page(false);
+    setShowParis12Page(false);
+    setShowParis13Page(false);
+    setShowParis14Page(false);
+    setShowParis15Page(false);
+    setShowParis16Page(false);
+    setShowParis17Page(false);
+    setShowParis18Page(false);
+    setShowParis19Page(false);
+    setShowParis20Page(false);
+    switch (n) {
+      case 1: setShowParis1Page(true); break;
+      case 2: setShowParis2Page(true); break;
+      case 3: setShowParis3Page(true); break;
+      case 4: setShowParis4Page(true); break;
+      case 5: setShowParis5Page(true); break;
+      case 6: setShowParis6Page(true); break;
+      case 7: setShowParis7Page(true); break;
+      case 8: setShowParis8Page(true); break;
+      case 9: setShowParis9Page(true); break;
+      case 10: setShowParis10Page(true); break;
+      case 11: setShowParis11Page(true); break;
+      case 12: setShowParis12Page(true); break;
+      case 13: setShowParis13Page(true); break;
+      case 14: setShowParis14Page(true); break;
+      case 15: setShowParis15Page(true); break;
+      case 16: setShowParis16Page(true); break;
+      case 17: setShowParis17Page(true); break;
+      case 18: setShowParis18Page(true); break;
+      case 19: setShowParis19Page(true); break;
+      case 20: setShowParis20Page(true); break;
+    }
+  };
+  const arrondissementLinks = Array.from({ length: 20 }, (_, i) => ({ label: `Location photobooth Paris ${i + 1}`, onClick: () => goToParisPage(i + 1) }));
 
   if (showQuotePage) {
     return <QuotePage 
@@ -221,83 +250,8 @@ function App() {
       onSEOPage={() => {
         setShowQuotePage(false);
         setShowSEOPage(true);
-      }}
-      onParis1Page={() => {
-        setShowQuotePage(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowQuotePage(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowQuotePage(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowQuotePage(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowQuotePage(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowQuotePage(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowQuotePage(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowQuotePage(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowQuotePage(false);
-        setShowParis9Page(true);
-      }}
-      onParis10Page={() => {
-        setShowQuotePage(false);
-        setShowParis10Page(true);
-      }}
-      onParis11Page={() => {
-        setShowQuotePage(false);
-        setShowParis11Page(true);
-      }}
-      onParis12Page={() => {
-        setShowQuotePage(false);
-        setShowParis12Page(true);
-      }}
-      onParis13Page={() => {
-        setShowQuotePage(false);
-        setShowParis13Page(true);
-      }}
-      onParis14Page={() => {
-        setShowQuotePage(false);
-        setShowParis14Page(true);
-      }}
-      onParis15Page={() => {
-        setShowQuotePage(false);
-        setShowParis15Page(true);
-      }}
-      onParis16Page={() => {
-        setShowQuotePage(false);
-        setShowParis16Page(true);
-      }}
-      onParis17Page={() => {
-        setShowQuotePage(false);
-        setShowParis17Page(true);
-      }}
-      onParis18Page={() => {
-        setShowQuotePage(false);
-        setShowParis18Page(true);
-      }}
-      onParis19Page={() => {
-        setShowQuotePage(false);
-        setShowParis19Page(true);
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -312,46 +266,11 @@ function App() {
         setShowPhotoboothDetails(false);
         setShowSEOPage(true);
       }}
-      onParis1Page={() => {
-        setShowPhotoboothDetails(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowPhotoboothDetails(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowPhotoboothDetails(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowPhotoboothDetails(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowPhotoboothDetails(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowPhotoboothDetails(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowPhotoboothDetails(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowPhotoboothDetails(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowPhotoboothDetails(false);
-        setShowParis9Page(true);
-      }}
       onQuoteRequest={() => {
         setShowPhotoboothDetails(false);
         openQuotePage('photoboothDetails');
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -370,46 +289,11 @@ function App() {
         setShowAIAnimations(false);
         setShowSEOPage(true);
       }}
-      onParis1Page={() => {
-        setShowAIAnimations(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowAIAnimations(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowAIAnimations(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowAIAnimations(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowAIAnimations(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowAIAnimations(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowAIAnimations(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowAIAnimations(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowAIAnimations(false);
-        setShowParis9Page(true);
-      }}
       onQuoteRequest={() => {
         setShowAIAnimations(false);
         openQuotePage('aiAnimations');
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -420,46 +304,11 @@ function App() {
         setShowDemoRequest(false);
         setShowSEOPage(true);
       }}
-      onParis1Page={() => {
-        setShowDemoRequest(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowDemoRequest(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowDemoRequest(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowDemoRequest(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowDemoRequest(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowDemoRequest(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowDemoRequest(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowDemoRequest(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowDemoRequest(false);
-        setShowParis9Page(true);
-      }}
       onQuoteRequest={() => {
         setShowDemoRequest(false);
         openQuotePage('demoRequest');
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -477,43 +326,8 @@ function App() {
       onAIAnimations={() => {
         setShowSEOPage(false);
         setShowAIAnimations(true);
-      }}
-      onParis1Page={() => {
-        setShowSEOPage(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowSEOPage(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowSEOPage(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowSEOPage(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowSEOPage(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowSEOPage(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowSEOPage(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowSEOPage(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowSEOPage(false);
-        setShowParis9Page(true);
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -535,43 +349,8 @@ function App() {
       onSEOPage={() => {
         setShowPhotographerAI(false);
         setShowSEOPage(true);
-      }}
-      onParis1Page={() => {
-        setShowPhotographerAI(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowPhotographerAI(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowPhotographerAI(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowPhotographerAI(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowPhotographerAI(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowPhotographerAI(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowPhotographerAI(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowPhotographerAI(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowPhotographerAI(false);
-        setShowParis9Page(true);
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -593,39 +372,8 @@ function App() {
       onSEOPage={() => {
         setShowParis1Page(false);
         setShowSEOPage(true);
-      }}
-      onParis2Page={() => {
-        setShowParis1Page(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowParis1Page(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowParis1Page(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowParis1Page(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowParis1Page(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowParis1Page(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowParis1Page(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowParis1Page(false);
-        setShowParis9Page(true);
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -647,39 +395,8 @@ function App() {
       onSEOPage={() => {
         setShowParis2Page(false);
         setShowSEOPage(true);
-      }}
-      onParis1Page={() => {
-        setShowParis2Page(false);
-        setShowParis1Page(true);
-      }}
-      onParis3Page={() => {
-        setShowParis2Page(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowParis2Page(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowParis2Page(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowParis2Page(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowParis2Page(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowParis2Page(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowParis2Page(false);
-        setShowParis9Page(true);
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -701,39 +418,8 @@ function App() {
       onSEOPage={() => {
         setShowParis3Page(false);
         setShowSEOPage(true);
-      }}
-      onParis1Page={() => {
-        setShowParis3Page(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowParis3Page(false);
-        setShowParis2Page(true);
-      }}
-      onParis4Page={() => {
-        setShowParis3Page(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowParis3Page(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowParis3Page(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowParis3Page(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowParis3Page(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowParis3Page(false);
-        setShowParis9Page(true);
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -755,39 +441,8 @@ function App() {
       onSEOPage={() => {
         setShowParis4Page(false);
         setShowSEOPage(true);
-      }}
-      onParis1Page={() => {
-        setShowParis4Page(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowParis4Page(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowParis4Page(false);
-        setShowParis3Page(true);
-      }}
-      onParis5Page={() => {
-        setShowParis4Page(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowParis4Page(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowParis4Page(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowParis4Page(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowParis4Page(false);
-        setShowParis9Page(true);
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -809,39 +464,8 @@ function App() {
       onSEOPage={() => {
         setShowParis5Page(false);
         setShowSEOPage(true);
-      }}
-      onParis1Page={() => {
-        setShowParis5Page(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowParis5Page(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowParis5Page(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowParis5Page(false);
-        setShowParis4Page(true);
-      }}
-      onParis6Page={() => {
-        setShowParis5Page(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowParis5Page(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowParis5Page(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowParis5Page(false);
-        setShowParis9Page(true);
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -863,39 +487,8 @@ function App() {
       onSEOPage={() => {
         setShowParis6Page(false);
         setShowSEOPage(true);
-      }}
-      onParis1Page={() => {
-        setShowParis6Page(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowParis6Page(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowParis6Page(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowParis6Page(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowParis6Page(false);
-        setShowParis5Page(true);
-      }}
-      onParis7Page={() => {
-        setShowParis6Page(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowParis6Page(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowParis6Page(false);
-        setShowParis9Page(true);
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -917,39 +510,8 @@ function App() {
       onSEOPage={() => {
         setShowParis7Page(false);
         setShowSEOPage(true);
-      }}
-      onParis1Page={() => {
-        setShowParis7Page(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowParis7Page(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowParis7Page(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowParis7Page(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowParis7Page(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowParis7Page(false);
-        setShowParis6Page(true);
-      }}
-      onParis8Page={() => {
-        setShowParis7Page(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowParis7Page(false);
-        setShowParis9Page(true);
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -971,39 +533,8 @@ function App() {
       onSEOPage={() => {
         setShowParis8Page(false);
         setShowSEOPage(true);
-      }}
-      onParis1Page={() => {
-        setShowParis8Page(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowParis8Page(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowParis8Page(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowParis8Page(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowParis8Page(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowParis8Page(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowParis8Page(false);
-        setShowParis7Page(true);
-      }}
-      onParis9Page={() => {
-        setShowParis8Page(false);
-        setShowParis9Page(true);
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -1025,39 +556,8 @@ function App() {
       onSEOPage={() => {
         setShowParis9Page(false);
         setShowSEOPage(true);
-      }}
-      onParis1Page={() => {
-        setShowParis9Page(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowParis9Page(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowParis9Page(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowParis9Page(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowParis9Page(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowParis9Page(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowParis9Page(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowParis9Page(false);
-        setShowParis8Page(true);
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -1079,43 +579,8 @@ function App() {
       onSEOPage={() => {
         setShowParis10Page(false);
         setShowSEOPage(true);
-      }}
-      onParis1Page={() => {
-        setShowParis10Page(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowParis10Page(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowParis10Page(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowParis10Page(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowParis10Page(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowParis10Page(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowParis10Page(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowParis10Page(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowParis10Page(false);
-        setShowParis9Page(true);
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -1137,47 +602,8 @@ function App() {
       onSEOPage={() => {
         setShowParis11Page(false);
         setShowSEOPage(true);
-      }}
-      onParis1Page={() => {
-        setShowParis11Page(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowParis11Page(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowParis11Page(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowParis11Page(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowParis11Page(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowParis11Page(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowParis11Page(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowParis11Page(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowParis11Page(false);
-        setShowParis9Page(true);
-      }}
-      onParis10Page={() => {
-        setShowParis11Page(false);
-        setShowParis10Page(true);
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -1199,51 +625,8 @@ function App() {
       onSEOPage={() => {
         setShowParis12Page(false);
         setShowSEOPage(true);
-      }}
-      onParis1Page={() => {
-        setShowParis12Page(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowParis12Page(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowParis12Page(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowParis12Page(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowParis12Page(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowParis12Page(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowParis12Page(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowParis12Page(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowParis12Page(false);
-        setShowParis9Page(true);
-      }}
-      onParis10Page={() => {
-        setShowParis12Page(false);
-        setShowParis10Page(true);
-      }}
-      onParis11Page={() => {
-        setShowParis12Page(false);
-        setShowParis11Page(true);
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -1265,55 +648,8 @@ function App() {
       onSEOPage={() => {
         setShowParis13Page(false);
         setShowSEOPage(true);
-      }}
-      onParis1Page={() => {
-        setShowParis13Page(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowParis13Page(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowParis13Page(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowParis13Page(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowParis13Page(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowParis13Page(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowParis13Page(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowParis13Page(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowParis13Page(false);
-        setShowParis9Page(true);
-      }}
-      onParis10Page={() => {
-        setShowParis13Page(false);
-        setShowParis10Page(true);
-      }}
-      onParis11Page={() => {
-        setShowParis13Page(false);
-        setShowParis11Page(true);
-      }}
-      onParis12Page={() => {
-        setShowParis13Page(false);
-        setShowParis12Page(true);
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -1335,59 +671,8 @@ function App() {
       onSEOPage={() => {
         setShowParis14Page(false);
         setShowSEOPage(true);
-      }}
-      onParis1Page={() => {
-        setShowParis14Page(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowParis14Page(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowParis14Page(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowParis14Page(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowParis14Page(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowParis14Page(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowParis14Page(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowParis14Page(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowParis14Page(false);
-        setShowParis9Page(true);
-      }}
-      onParis10Page={() => {
-        setShowParis14Page(false);
-        setShowParis10Page(true);
-      }}
-      onParis11Page={() => {
-        setShowParis14Page(false);
-        setShowParis11Page(true);
-      }}
-      onParis12Page={() => {
-        setShowParis14Page(false);
-        setShowParis12Page(true);
-      }}
-      onParis13Page={() => {
-        setShowParis14Page(false);
-        setShowParis13Page(true);
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -1409,63 +694,8 @@ function App() {
       onSEOPage={() => {
         setShowParis15Page(false);
         setShowSEOPage(true);
-      }}
-      onParis1Page={() => {
-        setShowParis15Page(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowParis15Page(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowParis15Page(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowParis15Page(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowParis15Page(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowParis15Page(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowParis15Page(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowParis15Page(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowParis15Page(false);
-        setShowParis9Page(true);
-      }}
-      onParis10Page={() => {
-        setShowParis15Page(false);
-        setShowParis10Page(true);
-      }}
-      onParis11Page={() => {
-        setShowParis15Page(false);
-        setShowParis11Page(true);
-      }}
-      onParis12Page={() => {
-        setShowParis15Page(false);
-        setShowParis12Page(true);
-      }}
-      onParis13Page={() => {
-        setShowParis15Page(false);
-        setShowParis13Page(true);
-      }}
-      onParis14Page={() => {
-        setShowParis15Page(false);
-        setShowParis14Page(true);
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -1487,67 +717,8 @@ function App() {
       onSEOPage={() => {
         setShowParis16Page(false);
         setShowSEOPage(true);
-      }}
-      onParis1Page={() => {
-        setShowParis16Page(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowParis16Page(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowParis16Page(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowParis16Page(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowParis16Page(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowParis16Page(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowParis16Page(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowParis16Page(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowParis16Page(false);
-        setShowParis9Page(true);
-      }}
-      onParis10Page={() => {
-        setShowParis16Page(false);
-        setShowParis10Page(true);
-      }}
-      onParis11Page={() => {
-        setShowParis16Page(false);
-        setShowParis11Page(true);
-      }}
-      onParis12Page={() => {
-        setShowParis16Page(false);
-        setShowParis12Page(true);
-      }}
-      onParis13Page={() => {
-        setShowParis16Page(false);
-        setShowParis13Page(true);
-      }}
-      onParis14Page={() => {
-        setShowParis16Page(false);
-        setShowParis14Page(true);
-      }}
-      onParis15Page={() => {
-        setShowParis16Page(false);
-        setShowParis15Page(true);
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -1569,71 +740,8 @@ function App() {
       onSEOPage={() => {
         setShowParis17Page(false);
         setShowSEOPage(true);
-      }}
-      onParis1Page={() => {
-        setShowParis17Page(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowParis17Page(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowParis17Page(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowParis17Page(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowParis17Page(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowParis17Page(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowParis17Page(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowParis17Page(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowParis17Page(false);
-        setShowParis9Page(true);
-      }}
-      onParis10Page={() => {
-        setShowParis17Page(false);
-        setShowParis10Page(true);
-      }}
-      onParis11Page={() => {
-        setShowParis17Page(false);
-        setShowParis11Page(true);
-      }}
-      onParis12Page={() => {
-        setShowParis17Page(false);
-        setShowParis12Page(true);
-      }}
-      onParis13Page={() => {
-        setShowParis17Page(false);
-        setShowParis13Page(true);
-      }}
-      onParis14Page={() => {
-        setShowParis17Page(false);
-        setShowParis14Page(true);
-      }}
-      onParis15Page={() => {
-        setShowParis17Page(false);
-        setShowParis15Page(true);
-      }}
-      onParis16Page={() => {
-        setShowParis17Page(false);
-        setShowParis16Page(true);
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -1655,75 +763,8 @@ function App() {
       onSEOPage={() => {
         setShowParis18Page(false);
         setShowSEOPage(true);
-      }}
-      onParis1Page={() => {
-        setShowParis18Page(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowParis18Page(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowParis18Page(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowParis18Page(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowParis18Page(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowParis18Page(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowParis18Page(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowParis18Page(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowParis18Page(false);
-        setShowParis9Page(true);
-      }}
-      onParis10Page={() => {
-        setShowParis18Page(false);
-        setShowParis10Page(true);
-      }}
-      onParis11Page={() => {
-        setShowParis18Page(false);
-        setShowParis11Page(true);
-      }}
-      onParis12Page={() => {
-        setShowParis18Page(false);
-        setShowParis12Page(true);
-      }}
-      onParis13Page={() => {
-        setShowParis18Page(false);
-        setShowParis13Page(true);
-      }}
-      onParis14Page={() => {
-        setShowParis18Page(false);
-        setShowParis14Page(true);
-      }}
-      onParis15Page={() => {
-        setShowParis18Page(false);
-        setShowParis15Page(true);
-      }}
-      onParis16Page={() => {
-        setShowParis18Page(false);
-        setShowParis16Page(true);
-      }}
-      onParis17Page={() => {
-        setShowParis18Page(false);
-        setShowParis17Page(true);
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -1745,79 +786,8 @@ function App() {
       onSEOPage={() => {
         setShowParis19Page(false);
         setShowSEOPage(true);
-      }}
-      onParis1Page={() => {
-        setShowParis19Page(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowParis19Page(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowParis19Page(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowParis19Page(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowParis19Page(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowParis19Page(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowParis19Page(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowParis19Page(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowParis19Page(false);
-        setShowParis9Page(true);
-      }}
-      onParis10Page={() => {
-        setShowParis19Page(false);
-        setShowParis10Page(true);
-      }}
-      onParis11Page={() => {
-        setShowParis19Page(false);
-        setShowParis11Page(true);
-      }}
-      onParis12Page={() => {
-        setShowParis19Page(false);
-        setShowParis12Page(true);
-      }}
-      onParis13Page={() => {
-        setShowParis19Page(false);
-        setShowParis13Page(true);
-      }}
-      onParis14Page={() => {
-        setShowParis19Page(false);
-        setShowParis14Page(true);
-      }}
-      onParis15Page={() => {
-        setShowParis19Page(false);
-        setShowParis15Page(true);
-      }}
-      onParis16Page={() => {
-        setShowParis19Page(false);
-        setShowParis16Page(true);
-      }}
-      onParis17Page={() => {
-        setShowParis19Page(false);
-        setShowParis17Page(true);
-      }}
-      onParis18Page={() => {
-        setShowParis19Page(false);
-        setShowParis18Page(true);
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 
@@ -1839,83 +809,8 @@ function App() {
       onSEOPage={() => {
         setShowParis20Page(false);
         setShowSEOPage(true);
-      }}
-      onParis1Page={() => {
-        setShowParis20Page(false);
-        setShowParis1Page(true);
-      }}
-      onParis2Page={() => {
-        setShowParis20Page(false);
-        setShowParis2Page(true);
-      }}
-      onParis3Page={() => {
-        setShowParis20Page(false);
-        setShowParis3Page(true);
-      }}
-      onParis4Page={() => {
-        setShowParis20Page(false);
-        setShowParis4Page(true);
-      }}
-      onParis5Page={() => {
-        setShowParis20Page(false);
-        setShowParis5Page(true);
-      }}
-      onParis6Page={() => {
-        setShowParis20Page(false);
-        setShowParis6Page(true);
-      }}
-      onParis7Page={() => {
-        setShowParis20Page(false);
-        setShowParis7Page(true);
-      }}
-      onParis8Page={() => {
-        setShowParis20Page(false);
-        setShowParis8Page(true);
-      }}
-      onParis9Page={() => {
-        setShowParis20Page(false);
-        setShowParis9Page(true);
-      }}
-      onParis10Page={() => {
-        setShowParis20Page(false);
-        setShowParis10Page(true);
-      }}
-      onParis11Page={() => {
-        setShowParis20Page(false);
-        setShowParis11Page(true);
-      }}
-      onParis12Page={() => {
-        setShowParis20Page(false);
-        setShowParis12Page(true);
-      }}
-      onParis13Page={() => {
-        setShowParis20Page(false);
-        setShowParis13Page(true);
-      }}
-      onParis14Page={() => {
-        setShowParis20Page(false);
-        setShowParis14Page(true);
-      }}
-      onParis15Page={() => {
-        setShowParis20Page(false);
-        setShowParis15Page(true);
-      }}
-      onParis16Page={() => {
-        setShowParis20Page(false);
-        setShowParis16Page(true);
-      }}
-      onParis17Page={() => {
-        setShowParis20Page(false);
-        setShowParis17Page(true);
-      }}
-      onParis18Page={() => {
-        setShowParis20Page(false);
-        setShowParis18Page(true);
-      }}
-      onParis19Page={() => {
-        setShowParis20Page(false);
-        setShowParis19Page(true);
-      }}
+    }}
+      arrondissementLinks={arrondissementLinks}
     />;
   }
 

--- a/src/components/AIAnimationsPage.tsx
+++ b/src/components/AIAnimationsPage.tsx
@@ -28,19 +28,11 @@ interface AIAnimationsPageProps {
   onDemoRequest: () => void;
   onPhotoboothDetails?: () => void;
   onSEOPage?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
   onQuoteRequest?: () => void;
-  onParis9Page?: () => void;
 }
 
-const AIAnimationsPage: React.FC<AIAnimationsPageProps> = ({ onBack, onDemoRequest, onPhotoboothDetails, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onQuoteRequest, onParis9Page }) => {
+const AIAnimationsPage: React.FC<AIAnimationsPageProps> = ({ onBack, onDemoRequest, onPhotoboothDetails, onSEOPage, onQuoteRequest , arrondissementLinks }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -557,17 +549,7 @@ const AIAnimationsPage: React.FC<AIAnimationsPageProps> = ({ onBack, onDemoReque
       <Footer
         onSEOPage={onSEOPage}
         onPhotoboothDetails={onPhotoboothDetails}
-        arrondissementLinks={[
-          { label: 'Location photobooth Paris 1', onClick: onParis1Page },
-          { label: 'Location photobooth Paris 2', onClick: onParis2Page },
-          { label: 'Location photobooth Paris 3', onClick: onParis3Page },
-          { label: 'Location photobooth Paris 4', onClick: onParis4Page },
-          { label: 'Location photobooth Paris 5', onClick: onParis5Page },
-          { label: 'Location photobooth Paris 6', onClick: onParis6Page },
-          { label: 'Location photobooth Paris 7', onClick: onParis7Page },
-          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
-          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
-        ]}
+        arrondissementLinks={arrondissementLinks}
       />
     </div>
   );

--- a/src/components/DemoRequestPage.tsx
+++ b/src/components/DemoRequestPage.tsx
@@ -20,19 +20,11 @@ import Footer from './Footer';
 interface DemoRequestPageProps {
   onBack: () => void;
   onSEOPage?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
   onQuoteRequest?: () => void;
-  onParis9Page?: () => void;
 }
 
-const DemoRequestPage: React.FC<DemoRequestPageProps> = ({ onBack, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onQuoteRequest, onParis9Page }) => {
+const DemoRequestPage: React.FC<DemoRequestPageProps> = ({ onBack, onSEOPage, onQuoteRequest , arrondissementLinks }) => {
   const [currentStep, setCurrentStep] = useState(1);
   const [formData, setFormData] = useState({
     demoType: '', // 'live' or 'video'
@@ -467,17 +459,7 @@ const DemoRequestPage: React.FC<DemoRequestPageProps> = ({ onBack, onSEOPage, on
       {/* Footer */}
       <Footer
         onSEOPage={onSEOPage}
-        arrondissementLinks={[
-          { label: 'Location photobooth Paris 1', onClick: onParis1Page },
-          { label: 'Location photobooth Paris 2', onClick: onParis2Page },
-          { label: 'Location photobooth Paris 3', onClick: onParis3Page },
-          { label: 'Location photobooth Paris 4', onClick: onParis4Page },
-          { label: 'Location photobooth Paris 5', onClick: onParis5Page },
-          { label: 'Location photobooth Paris 6', onClick: onParis6Page },
-          { label: 'Location photobooth Paris 7', onClick: onParis7Page },
-          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
-          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
-        ]}
+        arrondissementLinks={arrondissementLinks}
       />
     </div>
   );

--- a/src/components/Paris10Page.tsx
+++ b/src/components/Paris10Page.tsx
@@ -16,15 +16,7 @@ interface Paris10PageProps {
   onPhotoboothDetails?: () => void;
   onAIAnimations?: () => void;
   onSEOPage?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
-  onParis9Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
 const Paris10Page: React.FC<Paris10PageProps> = ({
@@ -32,17 +24,7 @@ const Paris10Page: React.FC<Paris10PageProps> = ({
   onQuoteRequest,
   onPhotoboothDetails,
   onAIAnimations,
-  onSEOPage,
-  onParis1Page,
-  onParis2Page,
-  onParis3Page,
-  onParis4Page,
-  onParis5Page,
-  onParis6Page,
-  onParis7Page,
-  onParis8Page,
-  onParis9Page,
-}) => {
+  onSEOPage, arrondissementLinks }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -231,18 +213,7 @@ const Paris10Page: React.FC<Paris10PageProps> = ({
       <Footer
         onSEOPage={onSEOPage}
         onPhotoboothDetails={onPhotoboothDetails}
-        arrondissementLinks={[
-          { label: 'Location photobooth Paris 1', onClick: onParis1Page || (() => {}) },
-          { label: 'Location photobooth Paris 2', onClick: onParis2Page || (() => {}) },
-          { label: 'Location photobooth Paris 3', onClick: onParis3Page || (() => {}) },
-          { label: 'Location photobooth Paris 4', onClick: onParis4Page || (() => {}) },
-          { label: 'Location photobooth Paris 5', onClick: onParis5Page || (() => {}) },
-          { label: 'Location photobooth Paris 6', onClick: onParis6Page || (() => {}) },
-          { label: 'Location photobooth Paris 7', onClick: onParis7Page || (() => {}) },
-          { label: 'Location photobooth Paris 8', onClick: onParis8Page || (() => {}) },
-          { label: 'Location photobooth Paris 9', onClick: onParis9Page || (() => {}) },
-          { label: 'Location photobooth Paris 10', onClick: onBack },
-        ]}
+        arrondissementLinks={arrondissementLinks}
       />
     </div>
   );

--- a/src/components/Paris11Page.tsx
+++ b/src/components/Paris11Page.tsx
@@ -20,16 +20,7 @@ interface Paris11PageProps {
   onPhotoboothDetails?: () => void;
   onAIAnimations?: () => void;
   onSEOPage?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
-  onParis9Page?: () => void;
-  onParis10Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
 const Paris11Page: React.FC<Paris11PageProps> = ({
@@ -37,18 +28,7 @@ const Paris11Page: React.FC<Paris11PageProps> = ({
   onQuoteRequest,
   onPhotoboothDetails,
   onAIAnimations,
-  onSEOPage,
-  onParis1Page,
-  onParis2Page,
-  onParis3Page,
-  onParis4Page,
-  onParis5Page,
-  onParis6Page,
-  onParis7Page,
-  onParis8Page,
-  onParis9Page,
-  onParis10Page,
-}) => {
+  onSEOPage, arrondissementLinks }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -261,19 +241,7 @@ const Paris11Page: React.FC<Paris11PageProps> = ({
       <Footer
         onSEOPage={onSEOPage}
         onPhotoboothDetails={onPhotoboothDetails}
-        arrondissementLinks={[
-          { label: 'Location photobooth Paris 1', onClick: onParis1Page || (() => {}) },
-          { label: 'Location photobooth Paris 2', onClick: onParis2Page || (() => {}) },
-          { label: 'Location photobooth Paris 3', onClick: onParis3Page || (() => {}) },
-          { label: 'Location photobooth Paris 4', onClick: onParis4Page || (() => {}) },
-          { label: 'Location photobooth Paris 5', onClick: onParis5Page || (() => {}) },
-          { label: 'Location photobooth Paris 6', onClick: onParis6Page || (() => {}) },
-          { label: 'Location photobooth Paris 7', onClick: onParis7Page || (() => {}) },
-          { label: 'Location photobooth Paris 8', onClick: onParis8Page || (() => {}) },
-          { label: 'Location photobooth Paris 9', onClick: onParis9Page || (() => {}) },
-          { label: 'Location photobooth Paris 10', onClick: onParis10Page || (() => {}) },
-          { label: 'Location photobooth Paris 11', onClick: onBack },
-        ]}
+        arrondissementLinks={arrondissementLinks}
       />
     </div>
   );

--- a/src/components/Paris12Page.tsx
+++ b/src/components/Paris12Page.tsx
@@ -17,17 +17,7 @@ interface Paris12PageProps {
   onPhotoboothDetails?: () => void;
   onAIAnimations?: () => void;
   onSEOPage?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
-  onParis9Page?: () => void;
-  onParis10Page?: () => void;
-  onParis11Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
 const Paris12Page: React.FC<Paris12PageProps> = ({
@@ -35,19 +25,7 @@ const Paris12Page: React.FC<Paris12PageProps> = ({
   onQuoteRequest,
   onPhotoboothDetails,
   onAIAnimations,
-  onSEOPage,
-  onParis1Page,
-  onParis2Page,
-  onParis3Page,
-  onParis4Page,
-  onParis5Page,
-  onParis6Page,
-  onParis7Page,
-  onParis8Page,
-  onParis9Page,
-  onParis10Page,
-  onParis11Page,
-}) => {
+  onSEOPage, arrondissementLinks }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -239,20 +217,7 @@ const Paris12Page: React.FC<Paris12PageProps> = ({
       <Footer
         onSEOPage={onSEOPage}
         onPhotoboothDetails={onPhotoboothDetails}
-        arrondissementLinks={[
-          { label: 'Location photobooth Paris 1', onClick: onParis1Page || (() => {}) },
-          { label: 'Location photobooth Paris 2', onClick: onParis2Page || (() => {}) },
-          { label: 'Location photobooth Paris 3', onClick: onParis3Page || (() => {}) },
-          { label: 'Location photobooth Paris 4', onClick: onParis4Page || (() => {}) },
-          { label: 'Location photobooth Paris 5', onClick: onParis5Page || (() => {}) },
-          { label: 'Location photobooth Paris 6', onClick: onParis6Page || (() => {}) },
-          { label: 'Location photobooth Paris 7', onClick: onParis7Page || (() => {}) },
-          { label: 'Location photobooth Paris 8', onClick: onParis8Page || (() => {}) },
-          { label: 'Location photobooth Paris 9', onClick: onParis9Page || (() => {}) },
-          { label: 'Location photobooth Paris 10', onClick: onParis10Page || (() => {}) },
-          { label: 'Location photobooth Paris 11', onClick: onParis11Page || (() => {}) },
-          { label: 'Location photobooth Paris 12', onClick: onBack },
-        ]}
+        arrondissementLinks={arrondissementLinks}
       />
     </div>
   );

--- a/src/components/Paris13Page.tsx
+++ b/src/components/Paris13Page.tsx
@@ -9,18 +9,7 @@ interface Paris13PageProps {
   onPhotoboothDetails?: () => void;
   onAIAnimations?: () => void;
   onSEOPage?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
-  onParis9Page?: () => void;
-  onParis10Page?: () => void;
-  onParis11Page?: () => void;
-  onParis12Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
 const Paris13Page: React.FC<Paris13PageProps> = ({
@@ -28,20 +17,7 @@ const Paris13Page: React.FC<Paris13PageProps> = ({
   onQuoteRequest,
   onPhotoboothDetails,
   onAIAnimations,
-  onSEOPage,
-  onParis1Page,
-  onParis2Page,
-  onParis3Page,
-  onParis4Page,
-  onParis5Page,
-  onParis6Page,
-  onParis7Page,
-  onParis8Page,
-  onParis9Page,
-  onParis10Page,
-  onParis11Page,
-  onParis12Page,
-}) => {
+  onSEOPage, arrondissementLinks }) => {
   return (
     <ArrondissementPageLayout
       arrondissement={13}
@@ -50,21 +26,7 @@ const Paris13Page: React.FC<Paris13PageProps> = ({
       onPhotoboothDetails={onPhotoboothDetails}
       onAIAnimations={onAIAnimations}
       onSEOPage={onSEOPage}
-      arrondissementLinks={[
-        { label: 'Location photobooth Paris 1', onClick: onParis1Page || (() => {}) },
-        { label: 'Location photobooth Paris 2', onClick: onParis2Page || (() => {}) },
-        { label: 'Location photobooth Paris 3', onClick: onParis3Page || (() => {}) },
-        { label: 'Location photobooth Paris 4', onClick: onParis4Page || (() => {}) },
-        { label: 'Location photobooth Paris 5', onClick: onParis5Page || (() => {}) },
-        { label: 'Location photobooth Paris 6', onClick: onParis6Page || (() => {}) },
-        { label: 'Location photobooth Paris 7', onClick: onParis7Page || (() => {}) },
-        { label: 'Location photobooth Paris 8', onClick: onParis8Page || (() => {}) },
-        { label: 'Location photobooth Paris 9', onClick: onParis9Page || (() => {}) },
-        { label: 'Location photobooth Paris 10', onClick: onParis10Page || (() => {}) },
-        { label: 'Location photobooth Paris 11', onClick: onParis11Page || (() => {}) },
-        { label: 'Location photobooth Paris 12', onClick: onParis12Page || (() => {}) },
-        { label: 'Location photobooth Paris 13', onClick: onBack },
-      ]}
+      arrondissementLinks={arrondissementLinks}
     >
       <ArrondissementSection title="Louer un photobooth Paris 13eme arrondissement avec The Pix" icon={Heart}>
         <p>

--- a/src/components/Paris14Page.tsx
+++ b/src/components/Paris14Page.tsx
@@ -9,19 +9,7 @@ interface Paris14PageProps {
   onPhotoboothDetails?: () => void;
   onAIAnimations?: () => void;
   onSEOPage?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
-  onParis9Page?: () => void;
-  onParis10Page?: () => void;
-  onParis11Page?: () => void;
-  onParis12Page?: () => void;
-  onParis13Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
 const Paris14Page: React.FC<Paris14PageProps> = ({
@@ -29,21 +17,7 @@ const Paris14Page: React.FC<Paris14PageProps> = ({
   onQuoteRequest,
   onPhotoboothDetails,
   onAIAnimations,
-  onSEOPage,
-  onParis1Page,
-  onParis2Page,
-  onParis3Page,
-  onParis4Page,
-  onParis5Page,
-  onParis6Page,
-  onParis7Page,
-  onParis8Page,
-  onParis9Page,
-  onParis10Page,
-  onParis11Page,
-  onParis12Page,
-  onParis13Page,
-}) => {
+  onSEOPage, arrondissementLinks }) => {
   return (
     <ArrondissementPageLayout
       arrondissement={14}
@@ -52,22 +26,7 @@ const Paris14Page: React.FC<Paris14PageProps> = ({
       onPhotoboothDetails={onPhotoboothDetails}
       onAIAnimations={onAIAnimations}
       onSEOPage={onSEOPage}
-      arrondissementLinks={[
-        { label: 'Location photobooth Paris 1', onClick: onParis1Page || (() => {}) },
-        { label: 'Location photobooth Paris 2', onClick: onParis2Page || (() => {}) },
-        { label: 'Location photobooth Paris 3', onClick: onParis3Page || (() => {}) },
-        { label: 'Location photobooth Paris 4', onClick: onParis4Page || (() => {}) },
-        { label: 'Location photobooth Paris 5', onClick: onParis5Page || (() => {}) },
-        { label: 'Location photobooth Paris 6', onClick: onParis6Page || (() => {}) },
-        { label: 'Location photobooth Paris 7', onClick: onParis7Page || (() => {}) },
-        { label: 'Location photobooth Paris 8', onClick: onParis8Page || (() => {}) },
-        { label: 'Location photobooth Paris 9', onClick: onParis9Page || (() => {}) },
-        { label: 'Location photobooth Paris 10', onClick: onParis10Page || (() => {}) },
-        { label: 'Location photobooth Paris 11', onClick: onParis11Page || (() => {}) },
-        { label: 'Location photobooth Paris 12', onClick: onParis12Page || (() => {}) },
-        { label: 'Location photobooth Paris 13', onClick: onParis13Page || (() => {}) },
-        { label: 'Location photobooth Paris 14', onClick: onBack },
-      ]}
+      arrondissementLinks={arrondissementLinks}
     >
       <ArrondissementSection
         title="Louer un photobooth Paris 14eme arrondissement avec The Pix"

--- a/src/components/Paris15Page.tsx
+++ b/src/components/Paris15Page.tsx
@@ -9,20 +9,7 @@ interface Paris15PageProps {
   onPhotoboothDetails?: () => void;
   onAIAnimations?: () => void;
   onSEOPage?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
-  onParis9Page?: () => void;
-  onParis10Page?: () => void;
-  onParis11Page?: () => void;
-  onParis12Page?: () => void;
-  onParis13Page?: () => void;
-  onParis14Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
 const Paris15Page: React.FC<Paris15PageProps> = ({
@@ -30,22 +17,7 @@ const Paris15Page: React.FC<Paris15PageProps> = ({
   onQuoteRequest,
   onPhotoboothDetails,
   onAIAnimations,
-  onSEOPage,
-  onParis1Page,
-  onParis2Page,
-  onParis3Page,
-  onParis4Page,
-  onParis5Page,
-  onParis6Page,
-  onParis7Page,
-  onParis8Page,
-  onParis9Page,
-  onParis10Page,
-  onParis11Page,
-  onParis12Page,
-  onParis13Page,
-  onParis14Page,
-}) => {
+  onSEOPage, arrondissementLinks }) => {
   return (
     <ArrondissementPageLayout
       arrondissement={15}
@@ -54,23 +26,7 @@ const Paris15Page: React.FC<Paris15PageProps> = ({
       onPhotoboothDetails={onPhotoboothDetails}
       onAIAnimations={onAIAnimations}
       onSEOPage={onSEOPage}
-      arrondissementLinks={[
-        { label: 'Location photobooth Paris 1', onClick: onParis1Page || (() => {}) },
-        { label: 'Location photobooth Paris 2', onClick: onParis2Page || (() => {}) },
-        { label: 'Location photobooth Paris 3', onClick: onParis3Page || (() => {}) },
-        { label: 'Location photobooth Paris 4', onClick: onParis4Page || (() => {}) },
-        { label: 'Location photobooth Paris 5', onClick: onParis5Page || (() => {}) },
-        { label: 'Location photobooth Paris 6', onClick: onParis6Page || (() => {}) },
-        { label: 'Location photobooth Paris 7', onClick: onParis7Page || (() => {}) },
-        { label: 'Location photobooth Paris 8', onClick: onParis8Page || (() => {}) },
-        { label: 'Location photobooth Paris 9', onClick: onParis9Page || (() => {}) },
-        { label: 'Location photobooth Paris 10', onClick: onParis10Page || (() => {}) },
-        { label: 'Location photobooth Paris 11', onClick: onParis11Page || (() => {}) },
-        { label: 'Location photobooth Paris 12', onClick: onParis12Page || (() => {}) },
-        { label: 'Location photobooth Paris 13', onClick: onParis13Page || (() => {}) },
-        { label: 'Location photobooth Paris 14', onClick: onParis14Page || (() => {}) },
-        { label: 'Location photobooth Paris 15', onClick: onBack },
-      ]}
+      arrondissementLinks={arrondissementLinks}
     >
       <ArrondissementSection
         title="Louer un photobooth Paris 15eme arrondissement avec The Pix"

--- a/src/components/Paris16Page.tsx
+++ b/src/components/Paris16Page.tsx
@@ -9,21 +9,7 @@ interface Paris16PageProps {
   onPhotoboothDetails?: () => void;
   onAIAnimations?: () => void;
   onSEOPage?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
-  onParis9Page?: () => void;
-  onParis10Page?: () => void;
-  onParis11Page?: () => void;
-  onParis12Page?: () => void;
-  onParis13Page?: () => void;
-  onParis14Page?: () => void;
-  onParis15Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
 const Paris16Page: React.FC<Paris16PageProps> = ({
@@ -31,23 +17,7 @@ const Paris16Page: React.FC<Paris16PageProps> = ({
   onQuoteRequest,
   onPhotoboothDetails,
   onAIAnimations,
-  onSEOPage,
-  onParis1Page,
-  onParis2Page,
-  onParis3Page,
-  onParis4Page,
-  onParis5Page,
-  onParis6Page,
-  onParis7Page,
-  onParis8Page,
-  onParis9Page,
-  onParis10Page,
-  onParis11Page,
-  onParis12Page,
-  onParis13Page,
-  onParis14Page,
-  onParis15Page,
-}) => {
+  onSEOPage, arrondissementLinks }) => {
   return (
     <ArrondissementPageLayout
       arrondissement={16}
@@ -56,24 +26,7 @@ const Paris16Page: React.FC<Paris16PageProps> = ({
       onPhotoboothDetails={onPhotoboothDetails}
       onAIAnimations={onAIAnimations}
       onSEOPage={onSEOPage}
-      arrondissementLinks={[
-        { label: 'Location photobooth Paris 1', onClick: onParis1Page || (() => {}) },
-        { label: 'Location photobooth Paris 2', onClick: onParis2Page || (() => {}) },
-        { label: 'Location photobooth Paris 3', onClick: onParis3Page || (() => {}) },
-        { label: 'Location photobooth Paris 4', onClick: onParis4Page || (() => {}) },
-        { label: 'Location photobooth Paris 5', onClick: onParis5Page || (() => {}) },
-        { label: 'Location photobooth Paris 6', onClick: onParis6Page || (() => {}) },
-        { label: 'Location photobooth Paris 7', onClick: onParis7Page || (() => {}) },
-        { label: 'Location photobooth Paris 8', onClick: onParis8Page || (() => {}) },
-        { label: 'Location photobooth Paris 9', onClick: onParis9Page || (() => {}) },
-        { label: 'Location photobooth Paris 10', onClick: onParis10Page || (() => {}) },
-        { label: 'Location photobooth Paris 11', onClick: onParis11Page || (() => {}) },
-        { label: 'Location photobooth Paris 12', onClick: onParis12Page || (() => {}) },
-        { label: 'Location photobooth Paris 13', onClick: onParis13Page || (() => {}) },
-        { label: 'Location photobooth Paris 14', onClick: onParis14Page || (() => {}) },
-        { label: 'Location photobooth Paris 15', onClick: onParis15Page || (() => {}) },
-        { label: 'Location photobooth Paris 16', onClick: onBack },
-      ]}
+      arrondissementLinks={arrondissementLinks}
     >
       <ArrondissementSection
         title="Location photobooth Paris 16e avec The Pix"

--- a/src/components/Paris17Page.tsx
+++ b/src/components/Paris17Page.tsx
@@ -9,22 +9,7 @@ interface Paris17PageProps {
   onPhotoboothDetails?: () => void;
   onAIAnimations?: () => void;
   onSEOPage?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
-  onParis9Page?: () => void;
-  onParis10Page?: () => void;
-  onParis11Page?: () => void;
-  onParis12Page?: () => void;
-  onParis13Page?: () => void;
-  onParis14Page?: () => void;
-  onParis15Page?: () => void;
-  onParis16Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
 const Paris17Page: React.FC<Paris17PageProps> = ({
@@ -32,24 +17,7 @@ const Paris17Page: React.FC<Paris17PageProps> = ({
   onQuoteRequest,
   onPhotoboothDetails,
   onAIAnimations,
-  onSEOPage,
-  onParis1Page,
-  onParis2Page,
-  onParis3Page,
-  onParis4Page,
-  onParis5Page,
-  onParis6Page,
-  onParis7Page,
-  onParis8Page,
-  onParis9Page,
-  onParis10Page,
-  onParis11Page,
-  onParis12Page,
-  onParis13Page,
-  onParis14Page,
-  onParis15Page,
-  onParis16Page,
-}) => {
+  onSEOPage, arrondissementLinks }) => {
   return (
     <ArrondissementPageLayout
       arrondissement={17}
@@ -58,25 +26,7 @@ const Paris17Page: React.FC<Paris17PageProps> = ({
       onPhotoboothDetails={onPhotoboothDetails}
       onAIAnimations={onAIAnimations}
       onSEOPage={onSEOPage}
-      arrondissementLinks={[
-        { label: 'Location photobooth Paris 1', onClick: onParis1Page || (() => {}) },
-        { label: 'Location photobooth Paris 2', onClick: onParis2Page || (() => {}) },
-        { label: 'Location photobooth Paris 3', onClick: onParis3Page || (() => {}) },
-        { label: 'Location photobooth Paris 4', onClick: onParis4Page || (() => {}) },
-        { label: 'Location photobooth Paris 5', onClick: onParis5Page || (() => {}) },
-        { label: 'Location photobooth Paris 6', onClick: onParis6Page || (() => {}) },
-        { label: 'Location photobooth Paris 7', onClick: onParis7Page || (() => {}) },
-        { label: 'Location photobooth Paris 8', onClick: onParis8Page || (() => {}) },
-        { label: 'Location photobooth Paris 9', onClick: onParis9Page || (() => {}) },
-        { label: 'Location photobooth Paris 10', onClick: onParis10Page || (() => {}) },
-        { label: 'Location photobooth Paris 11', onClick: onParis11Page || (() => {}) },
-        { label: 'Location photobooth Paris 12', onClick: onParis12Page || (() => {}) },
-        { label: 'Location photobooth Paris 13', onClick: onParis13Page || (() => {}) },
-        { label: 'Location photobooth Paris 14', onClick: onParis14Page || (() => {}) },
-        { label: 'Location photobooth Paris 15', onClick: onParis15Page || (() => {}) },
-        { label: 'Location photobooth Paris 16', onClick: onParis16Page || (() => {}) },
-        { label: 'Location photobooth Paris 17', onClick: onBack },
-      ]}
+      arrondissementLinks={arrondissementLinks}
     >
       <ArrondissementSection
         title="Louer un photobooth Paris 17eme arrondissement avec The Pix"

--- a/src/components/Paris18Page.tsx
+++ b/src/components/Paris18Page.tsx
@@ -9,23 +9,7 @@ interface Paris18PageProps {
   onPhotoboothDetails?: () => void;
   onAIAnimations?: () => void;
   onSEOPage?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
-  onParis9Page?: () => void;
-  onParis10Page?: () => void;
-  onParis11Page?: () => void;
-  onParis12Page?: () => void;
-  onParis13Page?: () => void;
-  onParis14Page?: () => void;
-  onParis15Page?: () => void;
-  onParis16Page?: () => void;
-  onParis17Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
 const Paris18Page: React.FC<Paris18PageProps> = ({
@@ -33,25 +17,7 @@ const Paris18Page: React.FC<Paris18PageProps> = ({
   onQuoteRequest,
   onPhotoboothDetails,
   onAIAnimations,
-  onSEOPage,
-  onParis1Page,
-  onParis2Page,
-  onParis3Page,
-  onParis4Page,
-  onParis5Page,
-  onParis6Page,
-  onParis7Page,
-  onParis8Page,
-  onParis9Page,
-  onParis10Page,
-  onParis11Page,
-  onParis12Page,
-  onParis13Page,
-  onParis14Page,
-  onParis15Page,
-  onParis16Page,
-  onParis17Page,
-}) => {
+  onSEOPage, arrondissementLinks }) => {
   return (
     <ArrondissementPageLayout
       arrondissement={18}
@@ -60,26 +26,7 @@ const Paris18Page: React.FC<Paris18PageProps> = ({
       onPhotoboothDetails={onPhotoboothDetails}
       onAIAnimations={onAIAnimations}
       onSEOPage={onSEOPage}
-      arrondissementLinks={[
-        { label: 'Location photobooth Paris 1', onClick: onParis1Page || (() => {}) },
-        { label: 'Location photobooth Paris 2', onClick: onParis2Page || (() => {}) },
-        { label: 'Location photobooth Paris 3', onClick: onParis3Page || (() => {}) },
-        { label: 'Location photobooth Paris 4', onClick: onParis4Page || (() => {}) },
-        { label: 'Location photobooth Paris 5', onClick: onParis5Page || (() => {}) },
-        { label: 'Location photobooth Paris 6', onClick: onParis6Page || (() => {}) },
-        { label: 'Location photobooth Paris 7', onClick: onParis7Page || (() => {}) },
-        { label: 'Location photobooth Paris 8', onClick: onParis8Page || (() => {}) },
-        { label: 'Location photobooth Paris 9', onClick: onParis9Page || (() => {}) },
-        { label: 'Location photobooth Paris 10', onClick: onParis10Page || (() => {}) },
-        { label: 'Location photobooth Paris 11', onClick: onParis11Page || (() => {}) },
-        { label: 'Location photobooth Paris 12', onClick: onParis12Page || (() => {}) },
-        { label: 'Location photobooth Paris 13', onClick: onParis13Page || (() => {}) },
-        { label: 'Location photobooth Paris 14', onClick: onParis14Page || (() => {}) },
-        { label: 'Location photobooth Paris 15', onClick: onParis15Page || (() => {}) },
-        { label: 'Location photobooth Paris 16', onClick: onParis16Page || (() => {}) },
-        { label: 'Location photobooth Paris 17', onClick: onParis17Page || (() => {}) },
-        { label: 'Location photobooth Paris 18', onClick: onBack },
-      ]}
+      arrondissementLinks={arrondissementLinks}
     >
       <ArrondissementSection
         title="Louer un photobooth Paris 18eme arrondissement avec The Pix"

--- a/src/components/Paris19Page.tsx
+++ b/src/components/Paris19Page.tsx
@@ -9,24 +9,7 @@ interface Paris19PageProps {
   onPhotoboothDetails?: () => void;
   onAIAnimations?: () => void;
   onSEOPage?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
-  onParis9Page?: () => void;
-  onParis10Page?: () => void;
-  onParis11Page?: () => void;
-  onParis12Page?: () => void;
-  onParis13Page?: () => void;
-  onParis14Page?: () => void;
-  onParis15Page?: () => void;
-  onParis16Page?: () => void;
-  onParis17Page?: () => void;
-  onParis18Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
 const Paris19Page: React.FC<Paris19PageProps> = ({
@@ -34,26 +17,7 @@ const Paris19Page: React.FC<Paris19PageProps> = ({
   onQuoteRequest,
   onPhotoboothDetails,
   onAIAnimations,
-  onSEOPage,
-  onParis1Page,
-  onParis2Page,
-  onParis3Page,
-  onParis4Page,
-  onParis5Page,
-  onParis6Page,
-  onParis7Page,
-  onParis8Page,
-  onParis9Page,
-  onParis10Page,
-  onParis11Page,
-  onParis12Page,
-  onParis13Page,
-  onParis14Page,
-  onParis15Page,
-  onParis16Page,
-  onParis17Page,
-  onParis18Page,
-}) => {
+  onSEOPage, arrondissementLinks }) => {
   return (
     <ArrondissementPageLayout
       arrondissement={19}
@@ -62,27 +26,7 @@ const Paris19Page: React.FC<Paris19PageProps> = ({
       onPhotoboothDetails={onPhotoboothDetails}
       onAIAnimations={onAIAnimations}
       onSEOPage={onSEOPage}
-      arrondissementLinks={[
-        { label: 'Location photobooth Paris 1', onClick: onParis1Page || (() => {}) },
-        { label: 'Location photobooth Paris 2', onClick: onParis2Page || (() => {}) },
-        { label: 'Location photobooth Paris 3', onClick: onParis3Page || (() => {}) },
-        { label: 'Location photobooth Paris 4', onClick: onParis4Page || (() => {}) },
-        { label: 'Location photobooth Paris 5', onClick: onParis5Page || (() => {}) },
-        { label: 'Location photobooth Paris 6', onClick: onParis6Page || (() => {}) },
-        { label: 'Location photobooth Paris 7', onClick: onParis7Page || (() => {}) },
-        { label: 'Location photobooth Paris 8', onClick: onParis8Page || (() => {}) },
-        { label: 'Location photobooth Paris 9', onClick: onParis9Page || (() => {}) },
-        { label: 'Location photobooth Paris 10', onClick: onParis10Page || (() => {}) },
-        { label: 'Location photobooth Paris 11', onClick: onParis11Page || (() => {}) },
-        { label: 'Location photobooth Paris 12', onClick: onParis12Page || (() => {}) },
-        { label: 'Location photobooth Paris 13', onClick: onParis13Page || (() => {}) },
-        { label: 'Location photobooth Paris 14', onClick: onParis14Page || (() => {}) },
-        { label: 'Location photobooth Paris 15', onClick: onParis15Page || (() => {}) },
-        { label: 'Location photobooth Paris 16', onClick: onParis16Page || (() => {}) },
-        { label: 'Location photobooth Paris 17', onClick: onParis17Page || (() => {}) },
-        { label: 'Location photobooth Paris 18', onClick: onParis18Page || (() => {}) },
-        { label: 'Location photobooth Paris 19', onClick: onBack },
-      ]}
+      arrondissementLinks={arrondissementLinks}
     >
       <ArrondissementSection
         title="Louer un photobooth Paris 19eme arrondissement avec The Pix"

--- a/src/components/Paris1Page.tsx
+++ b/src/components/Paris1Page.tsx
@@ -19,17 +19,10 @@ interface Paris1PageProps {
   onPhotoboothDetails?: () => void;
   onAIAnimations?: () => void;
   onSEOPage?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
-  onParis9Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
-const Paris1Page: React.FC<Paris1PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onParis9Page }) => {
+const Paris1Page: React.FC<Paris1PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, arrondissementLinks }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -320,17 +313,7 @@ const Paris1Page: React.FC<Paris1PageProps> = ({ onBack, onQuoteRequest, onPhoto
       <Footer
         onSEOPage={onSEOPage}
         onPhotoboothDetails={onPhotoboothDetails}
-        arrondissementLinks={[
-          { label: 'Location photobooth Paris 1', onClick: onBack },
-          { label: 'Location photobooth Paris 2', onClick: onParis2Page },
-          { label: 'Location photobooth Paris 3', onClick: onParis3Page },
-          { label: 'Location photobooth Paris 4', onClick: onParis4Page },
-          { label: 'Location photobooth Paris 5', onClick: onParis5Page },
-          { label: 'Location photobooth Paris 6', onClick: onParis6Page },
-          { label: 'Location photobooth Paris 7', onClick: onParis7Page },
-          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
-          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
-        ]}
+        arrondissementLinks={arrondissementLinks}
       />
     </div>
   );

--- a/src/components/Paris20Page.tsx
+++ b/src/components/Paris20Page.tsx
@@ -9,25 +9,7 @@ interface Paris20PageProps {
   onPhotoboothDetails?: () => void;
   onAIAnimations?: () => void;
   onSEOPage?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
-  onParis9Page?: () => void;
-  onParis10Page?: () => void;
-  onParis11Page?: () => void;
-  onParis12Page?: () => void;
-  onParis13Page?: () => void;
-  onParis14Page?: () => void;
-  onParis15Page?: () => void;
-  onParis16Page?: () => void;
-  onParis17Page?: () => void;
-  onParis18Page?: () => void;
-  onParis19Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
 const Paris20Page: React.FC<Paris20PageProps> = ({
@@ -35,27 +17,7 @@ const Paris20Page: React.FC<Paris20PageProps> = ({
   onQuoteRequest,
   onPhotoboothDetails,
   onAIAnimations,
-  onSEOPage,
-  onParis1Page,
-  onParis2Page,
-  onParis3Page,
-  onParis4Page,
-  onParis5Page,
-  onParis6Page,
-  onParis7Page,
-  onParis8Page,
-  onParis9Page,
-  onParis10Page,
-  onParis11Page,
-  onParis12Page,
-  onParis13Page,
-  onParis14Page,
-  onParis15Page,
-  onParis16Page,
-  onParis17Page,
-  onParis18Page,
-  onParis19Page,
-}) => {
+  onSEOPage, arrondissementLinks }) => {
   return (
     <ArrondissementPageLayout
       arrondissement={20}
@@ -64,28 +26,7 @@ const Paris20Page: React.FC<Paris20PageProps> = ({
       onPhotoboothDetails={onPhotoboothDetails}
       onAIAnimations={onAIAnimations}
       onSEOPage={onSEOPage}
-      arrondissementLinks={[
-        { label: 'Location photobooth Paris 1', onClick: onParis1Page || (() => {}) },
-        { label: 'Location photobooth Paris 2', onClick: onParis2Page || (() => {}) },
-        { label: 'Location photobooth Paris 3', onClick: onParis3Page || (() => {}) },
-        { label: 'Location photobooth Paris 4', onClick: onParis4Page || (() => {}) },
-        { label: 'Location photobooth Paris 5', onClick: onParis5Page || (() => {}) },
-        { label: 'Location photobooth Paris 6', onClick: onParis6Page || (() => {}) },
-        { label: 'Location photobooth Paris 7', onClick: onParis7Page || (() => {}) },
-        { label: 'Location photobooth Paris 8', onClick: onParis8Page || (() => {}) },
-        { label: 'Location photobooth Paris 9', onClick: onParis9Page || (() => {}) },
-        { label: 'Location photobooth Paris 10', onClick: onParis10Page || (() => {}) },
-        { label: 'Location photobooth Paris 11', onClick: onParis11Page || (() => {}) },
-        { label: 'Location photobooth Paris 12', onClick: onParis12Page || (() => {}) },
-        { label: 'Location photobooth Paris 13', onClick: onParis13Page || (() => {}) },
-        { label: 'Location photobooth Paris 14', onClick: onParis14Page || (() => {}) },
-        { label: 'Location photobooth Paris 15', onClick: onParis15Page || (() => {}) },
-        { label: 'Location photobooth Paris 16', onClick: onParis16Page || (() => {}) },
-        { label: 'Location photobooth Paris 17', onClick: onParis17Page || (() => {}) },
-        { label: 'Location photobooth Paris 18', onClick: onParis18Page || (() => {}) },
-        { label: 'Location photobooth Paris 19', onClick: onParis19Page || (() => {}) },
-        { label: 'Location photobooth Paris 20', onClick: onBack },
-      ]}
+      arrondissementLinks={arrondissementLinks}
     >
       <ArrondissementSection
         title="Louer un photobooth Paris 20eme arrondissement avec The Pix"

--- a/src/components/Paris2Page.tsx
+++ b/src/components/Paris2Page.tsx
@@ -17,17 +17,10 @@ interface Paris2PageProps {
   onPhotoboothDetails?: () => void;
   onAIAnimations?: () => void;
   onSEOPage?: () => void;
-  onParis1Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
-  onParis9Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
-const Paris2Page: React.FC<Paris2PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onParis9Page }) => {
+const Paris2Page: React.FC<Paris2PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, arrondissementLinks }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -278,17 +271,7 @@ const Paris2Page: React.FC<Paris2PageProps> = ({ onBack, onQuoteRequest, onPhoto
       <Footer
         onSEOPage={onSEOPage}
         onPhotoboothDetails={onPhotoboothDetails}
-        arrondissementLinks={[
-          { label: 'Location photobooth Paris 1', onClick: onParis1Page },
-          { label: 'Location photobooth Paris 2', onClick: onBack },
-          { label: 'Location photobooth Paris 3', onClick: onParis3Page },
-          { label: 'Location photobooth Paris 4', onClick: onParis4Page },
-          { label: 'Location photobooth Paris 5', onClick: onParis5Page },
-          { label: 'Location photobooth Paris 6', onClick: onParis6Page },
-          { label: 'Location photobooth Paris 7', onClick: onParis7Page },
-          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
-          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
-        ]}
+        arrondissementLinks={arrondissementLinks}
       />
     </div>
   );

--- a/src/components/Paris3Page.tsx
+++ b/src/components/Paris3Page.tsx
@@ -19,17 +19,10 @@ interface Paris3PageProps {
   onPhotoboothDetails?: () => void;
   onAIAnimations?: () => void;
   onSEOPage?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
-  onParis9Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
-const Paris3Page: React.FC<Paris3PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onParis9Page }) => {
+const Paris3Page: React.FC<Paris3PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, arrondissementLinks }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -202,7 +195,7 @@ const Paris3Page: React.FC<Paris3PageProps> = ({ onBack, onQuoteRequest, onPhoto
               <div className="mt-6 bg-white p-6 rounded-xl">
                 <p className="text-gray-700">
                   <button 
-                    onClick={onParis2Page}
+                    onClick={arrondissementLinks[1].onClick}
                     className="text-blue-600 hover:text-blue-800 transition-colors underline"
                   >
                     Découvrez aussi nos services sur Paris 2.
@@ -265,17 +258,7 @@ const Paris3Page: React.FC<Paris3PageProps> = ({ onBack, onQuoteRequest, onPhoto
       <Footer
         onSEOPage={onSEOPage}
         onPhotoboothDetails={onPhotoboothDetails}
-        arrondissementLinks={[
-          { label: 'Location photobooth Paris 1', onClick: onParis1Page },
-          { label: 'Location photobooth Paris 2', onClick: onParis2Page },
-          { label: 'Location photobooth Paris 3', onClick: onBack },
-          { label: 'Location photobooth Paris 4', onClick: onParis4Page },
-          { label: 'Location photobooth Paris 5', onClick: onParis5Page },
-          { label: 'Location photobooth Paris 6', onClick: onParis6Page },
-          { label: 'Location photobooth Paris 7', onClick: onParis7Page },
-          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
-          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
-        ]}
+        arrondissementLinks={arrondissementLinks}
       />
     </div>
   );

--- a/src/components/Paris4Page.tsx
+++ b/src/components/Paris4Page.tsx
@@ -19,17 +19,10 @@ interface Paris4PageProps {
   onPhotoboothDetails?: () => void;
   onAIAnimations?: () => void;
   onSEOPage?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
-  onParis9Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
-const Paris4Page: React.FC<Paris4PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onParis9Page }) => {
+const Paris4Page: React.FC<Paris4PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, arrondissementLinks }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -223,21 +216,21 @@ const Paris4Page: React.FC<Paris4PageProps> = ({ onBack, onQuoteRequest, onPhoto
               <p className="text-gray-700 text-lg leading-relaxed mb-6">
                 Explorez aussi nos solutions sur mesure dans les arrondissements voisins : 
                 <button 
-                  onClick={onParis1Page}
+                  onClick={arrondissementLinks[0].onClick}
                   className="text-blue-600 hover:text-blue-800 transition-colors underline mx-1"
                 >
                   Photobooth Paris 1
                 </button>
                 pour les événements institutionnels, 
                 <button 
-                  onClick={onParis2Page}
+                  onClick={arrondissementLinks[1].onClick}
                   className="text-blue-600 hover:text-blue-800 transition-colors underline mx-1"
                 >
                   Photobooth Paris 2
                 </button>
                 idéal pour les lancements mode, ou 
                 <button 
-                  onClick={onParis3Page}
+                  onClick={arrondissementLinks[2].onClick}
                   className="text-blue-600 hover:text-blue-800 transition-colors underline mx-1"
                 >
                   Photobooth Paris 3
@@ -267,17 +260,7 @@ const Paris4Page: React.FC<Paris4PageProps> = ({ onBack, onQuoteRequest, onPhoto
       <Footer
         onSEOPage={onSEOPage}
         onPhotoboothDetails={onPhotoboothDetails}
-        arrondissementLinks={[
-          { label: 'Location photobooth Paris 1', onClick: onParis1Page },
-          { label: 'Location photobooth Paris 2', onClick: onParis2Page },
-          { label: 'Location photobooth Paris 3', onClick: onParis3Page },
-          { label: 'Location photobooth Paris 4', onClick: onBack },
-          { label: 'Location photobooth Paris 5', onClick: onParis5Page },
-          { label: 'Location photobooth Paris 6', onClick: onParis6Page },
-          { label: 'Location photobooth Paris 7', onClick: onParis7Page },
-          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
-          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
-        ]}
+        arrondissementLinks={arrondissementLinks}
       />
     </div>
   );

--- a/src/components/Paris5Page.tsx
+++ b/src/components/Paris5Page.tsx
@@ -20,17 +20,10 @@ interface Paris5PageProps {
   onPhotoboothDetails?: () => void;
   onAIAnimations?: () => void;
   onSEOPage?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
-  onParis9Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
-const Paris5Page: React.FC<Paris5PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis6Page, onParis7Page, onParis8Page, onParis9Page }) => {
+const Paris5Page: React.FC<Paris5PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, arrondissementLinks }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -259,17 +252,7 @@ const Paris5Page: React.FC<Paris5PageProps> = ({ onBack, onQuoteRequest, onPhoto
       <Footer
         onSEOPage={onSEOPage}
         onPhotoboothDetails={onPhotoboothDetails}
-        arrondissementLinks={[
-          { label: 'Location photobooth Paris 1', onClick: onParis1Page },
-          { label: 'Location photobooth Paris 2', onClick: onParis2Page },
-          { label: 'Location photobooth Paris 3', onClick: onParis3Page },
-          { label: 'Location photobooth Paris 4', onClick: onParis4Page },
-          { label: 'Location photobooth Paris 5', onClick: onBack },
-          { label: 'Location photobooth Paris 6', onClick: onParis6Page },
-          { label: 'Location photobooth Paris 7', onClick: onParis7Page },
-          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
-          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
-        ]}
+        arrondissementLinks={arrondissementLinks}
       />
     </div>
   );

--- a/src/components/Paris6Page.tsx
+++ b/src/components/Paris6Page.tsx
@@ -22,17 +22,10 @@ interface Paris6PageProps {
   onPhotoboothDetails?: () => void;
   onAIAnimations?: () => void;
   onSEOPage?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
-  onParis9Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
-const Paris6Page: React.FC<Paris6PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis7Page, onParis8Page, onParis9Page }) => {
+const Paris6Page: React.FC<Paris6PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, arrondissementLinks }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -314,17 +307,7 @@ const Paris6Page: React.FC<Paris6PageProps> = ({ onBack, onQuoteRequest, onPhoto
       <Footer
         onSEOPage={onSEOPage}
         onPhotoboothDetails={onPhotoboothDetails}
-        arrondissementLinks={[
-          { label: 'Location photobooth Paris 1', onClick: onParis1Page },
-          { label: 'Location photobooth Paris 2', onClick: onParis2Page },
-          { label: 'Location photobooth Paris 3', onClick: onParis3Page },
-          { label: 'Location photobooth Paris 4', onClick: onParis4Page },
-          { label: 'Location photobooth Paris 5', onClick: onParis5Page },
-          { label: 'Location photobooth Paris 6', onClick: onBack },
-          { label: 'Location photobooth Paris 7', onClick: onParis7Page },
-          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
-          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
-        ]}
+        arrondissementLinks={arrondissementLinks}
       />
     </div>
   );

--- a/src/components/Paris7Page.tsx
+++ b/src/components/Paris7Page.tsx
@@ -21,17 +21,10 @@ interface Paris7PageProps {
   onPhotoboothDetails?: () => void;
   onAIAnimations?: () => void;
   onSEOPage?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis8Page?: () => void;
-  onParis9Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
-const Paris7Page: React.FC<Paris7PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis8Page, onParis9Page }) => {
+const Paris7Page: React.FC<Paris7PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, arrondissementLinks }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -340,17 +333,7 @@ const Paris7Page: React.FC<Paris7PageProps> = ({ onBack, onQuoteRequest, onPhoto
       <Footer
         onSEOPage={onSEOPage}
         onPhotoboothDetails={onPhotoboothDetails}
-        arrondissementLinks={[
-          { label: 'Location photobooth Paris 1', onClick: onParis1Page },
-          { label: 'Location photobooth Paris 2', onClick: onParis2Page },
-          { label: 'Location photobooth Paris 3', onClick: onParis3Page },
-          { label: 'Location photobooth Paris 4', onClick: onParis4Page },
-          { label: 'Location photobooth Paris 5', onClick: onParis5Page },
-          { label: 'Location photobooth Paris 6', onClick: onParis6Page },
-          { label: 'Location photobooth Paris 7', onClick: onBack },
-          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
-          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
-        ]}
+        arrondissementLinks={arrondissementLinks}
       />
     </div>
   );

--- a/src/components/Paris8Page.tsx
+++ b/src/components/Paris8Page.tsx
@@ -21,14 +21,7 @@ interface Paris8PageProps {
   onPhotoboothDetails?: () => void;
   onAIAnimations?: () => void;
   onSEOPage?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis9Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
 const Paris8Page: React.FC<Paris8PageProps> = ({
@@ -36,16 +29,7 @@ const Paris8Page: React.FC<Paris8PageProps> = ({
   onQuoteRequest,
   onPhotoboothDetails,
   onAIAnimations,
-  onSEOPage,
-  onParis1Page,
-  onParis2Page,
-  onParis3Page,
-  onParis4Page,
-  onParis5Page,
-  onParis6Page,
-  onParis7Page,
-  onParis9Page,
-}) => {
+  onSEOPage, arrondissementLinks }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -339,17 +323,7 @@ const Paris8Page: React.FC<Paris8PageProps> = ({
       <Footer
         onSEOPage={onSEOPage}
         onPhotoboothDetails={onPhotoboothDetails}
-        arrondissementLinks={[
-          { label: 'Location photobooth Paris 1', onClick: onParis1Page },
-          { label: 'Location photobooth Paris 2', onClick: onParis2Page },
-          { label: 'Location photobooth Paris 3', onClick: onParis3Page },
-          { label: 'Location photobooth Paris 4', onClick: onParis4Page },
-          { label: 'Location photobooth Paris 5', onClick: onParis5Page },
-          { label: 'Location photobooth Paris 6', onClick: onParis6Page },
-          { label: 'Location photobooth Paris 7', onClick: onParis7Page },
-          { label: 'Location photobooth Paris 8', onClick: onBack },
-          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
-        ]}
+        arrondissementLinks={arrondissementLinks}
       />
     </div>
   );

--- a/src/components/Paris9Page.tsx
+++ b/src/components/Paris9Page.tsx
@@ -20,14 +20,7 @@ interface Paris9PageProps {
   onPhotoboothDetails?: () => void;
   onAIAnimations?: () => void;
   onSEOPage?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
 const Paris9Page: React.FC<Paris9PageProps> = ({
@@ -35,16 +28,7 @@ const Paris9Page: React.FC<Paris9PageProps> = ({
   onQuoteRequest,
   onPhotoboothDetails,
   onAIAnimations,
-  onSEOPage,
-  onParis1Page,
-  onParis2Page,
-  onParis3Page,
-  onParis4Page,
-  onParis5Page,
-  onParis6Page,
-  onParis7Page,
-  onParis8Page,
-}) => {
+  onSEOPage, arrondissementLinks }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -276,17 +260,7 @@ const Paris9Page: React.FC<Paris9PageProps> = ({
       <Footer
         onSEOPage={onSEOPage}
         onPhotoboothDetails={onPhotoboothDetails}
-        arrondissementLinks={[
-          { label: 'Location photobooth Paris 1', onClick: onParis1Page },
-          { label: 'Location photobooth Paris 2', onClick: onParis2Page },
-          { label: 'Location photobooth Paris 3', onClick: onParis3Page },
-          { label: 'Location photobooth Paris 4', onClick: onParis4Page },
-          { label: 'Location photobooth Paris 5', onClick: onParis5Page },
-          { label: 'Location photobooth Paris 6', onClick: onParis6Page },
-          { label: 'Location photobooth Paris 7', onClick: onParis7Page },
-          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
-          { label: 'Location photobooth Paris 9', onClick: onBack },
-        ]}
+        arrondissementLinks={arrondissementLinks}
       />
     </div>
   );

--- a/src/components/PhotoboothDetailsPage.tsx
+++ b/src/components/PhotoboothDetailsPage.tsx
@@ -19,19 +19,11 @@ import Footer from './Footer';
 interface PhotoboothDetailsPageProps {
   onBack: () => void;
   onAIAnimations?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
   onQuoteRequest?: () => void;
-  onParis9Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
-const PhotoboothDetailsPage: React.FC<PhotoboothDetailsPageProps> = ({ onBack, onAIAnimations, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onQuoteRequest, onParis9Page }) => {
+const PhotoboothDetailsPage: React.FC<PhotoboothDetailsPageProps> = ({ onBack, onAIAnimations, onQuoteRequest, arrondissementLinks}) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -535,17 +527,7 @@ const PhotoboothDetailsPage: React.FC<PhotoboothDetailsPageProps> = ({ onBack, o
 
       {/* Footer */}
       <Footer
-        arrondissementLinks={[
-          { label: 'Location photobooth Paris 1', onClick: onParis1Page },
-          { label: 'Location photobooth Paris 2', onClick: onParis2Page },
-          { label: 'Location photobooth Paris 3', onClick: onParis3Page },
-          { label: 'Location photobooth Paris 4', onClick: onParis4Page },
-          { label: 'Location photobooth Paris 5', onClick: onParis5Page },
-          { label: 'Location photobooth Paris 6', onClick: onParis6Page },
-          { label: 'Location photobooth Paris 7', onClick: onParis7Page },
-          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
-          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
-        ]}
+        arrondissementLinks={arrondissementLinks}
       />
     </div>
   );

--- a/src/components/PhotographerAIPage.tsx
+++ b/src/components/PhotographerAIPage.tsx
@@ -26,18 +26,10 @@ interface PhotographerAIPageProps {
   onPhotoboothDetails?: () => void;
   onAIAnimations?: () => void;
   onSEOPage?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
-  onParis9Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
-const PhotographerAIPage: React.FC<PhotographerAIPageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onParis9Page }) => {
+const PhotographerAIPage: React.FC<PhotographerAIPageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, arrondissementLinks }) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -509,17 +501,7 @@ const PhotographerAIPage: React.FC<PhotographerAIPageProps> = ({ onBack, onQuote
       <Footer
         onSEOPage={onSEOPage}
         onPhotoboothDetails={onPhotoboothDetails}
-        arrondissementLinks={[
-          { label: 'Location photobooth Paris 1', onClick: onParis1Page },
-          { label: 'Location photobooth Paris 2', onClick: onParis2Page },
-          { label: 'Location photobooth Paris 3', onClick: onParis3Page },
-          { label: 'Location photobooth Paris 4', onClick: onParis4Page },
-          { label: 'Location photobooth Paris 5', onClick: onParis5Page },
-          { label: 'Location photobooth Paris 6', onClick: onParis6Page },
-          { label: 'Location photobooth Paris 7', onClick: onParis7Page },
-          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
-          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
-        ]}
+        arrondissementLinks={arrondissementLinks}
       />
     </div>
   );

--- a/src/components/QuotePage.tsx
+++ b/src/components/QuotePage.tsx
@@ -17,28 +17,10 @@ import Footer from './Footer';
 interface QuotePageProps {
   onBack: () => void;
   onSEOPage?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
-  onParis9Page?: () => void;
-    onParis10Page?: () => void;
-    onParis11Page?: () => void;
-    onParis12Page?: () => void;
-    onParis13Page?: () => void;
-    onParis14Page?: () => void;
-    onParis15Page?: () => void;
-    onParis16Page?: () => void;
-    onParis17Page?: () => void;
-    onParis18Page?: () => void;
-    onParis19Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
   }
 
-const QuotePage: React.FC<QuotePageProps> = ({ onBack, onSEOPage, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onParis9Page, onParis10Page, onParis11Page, onParis12Page, onParis13Page, onParis14Page, onParis15Page, onParis16Page, onParis17Page, onParis18Page, onParis19Page }) => {
+const QuotePage: React.FC<QuotePageProps> = ({ onBack, onSEOPage, arrondissementLinks }) => {
   const [currentStep, setCurrentStep] = useState(1);
   const [formData, setFormData] = useState({
     clientType: '', // 'enterprise' or 'wedding'
@@ -554,27 +536,7 @@ const QuotePage: React.FC<QuotePageProps> = ({ onBack, onSEOPage, onParis1Page, 
       {/* Footer */}
       <Footer
         onSEOPage={onSEOPage}
-        arrondissementLinks={[
-          { label: 'Location photobooth Paris 1', onClick: onParis1Page },
-          { label: 'Location photobooth Paris 2', onClick: onParis2Page },
-          { label: 'Location photobooth Paris 3', onClick: onParis3Page },
-          { label: 'Location photobooth Paris 4', onClick: onParis4Page },
-          { label: 'Location photobooth Paris 5', onClick: onParis5Page },
-          { label: 'Location photobooth Paris 6', onClick: onParis6Page },
-          { label: 'Location photobooth Paris 7', onClick: onParis7Page },
-          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
-          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
-          { label: 'Location photobooth Paris 10', onClick: onParis10Page },
-          { label: 'Location photobooth Paris 11', onClick: onParis11Page },
-          { label: 'Location photobooth Paris 12', onClick: onParis12Page },
-          { label: 'Location photobooth Paris 13', onClick: onParis13Page },
-          { label: 'Location photobooth Paris 14', onClick: onParis14Page },
-          { label: 'Location photobooth Paris 15', onClick: onParis15Page },
-          { label: 'Location photobooth Paris 16', onClick: onParis16Page },
-          { label: 'Location photobooth Paris 17', onClick: onParis17Page },
-          { label: 'Location photobooth Paris 18', onClick: onParis18Page },
-          { label: 'Location photobooth Paris 19', onClick: onParis19Page },
-        ]}
+        arrondissementLinks={arrondissementLinks}
       />
     </div>
   );

--- a/src/components/SEOPage.tsx
+++ b/src/components/SEOPage.tsx
@@ -22,18 +22,10 @@ interface SEOPageProps {
   onQuoteRequest?: () => void;
   onPhotoboothDetails?: () => void;
   onAIAnimations?: () => void;
-  onParis1Page?: () => void;
-  onParis2Page?: () => void;
-  onParis3Page?: () => void;
-  onParis4Page?: () => void;
-  onParis5Page?: () => void;
-  onParis6Page?: () => void;
-  onParis7Page?: () => void;
-  onParis8Page?: () => void;
-  onParis9Page?: () => void;
+  arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
-const SEOPage: React.FC<SEOPageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onParis1Page, onParis2Page, onParis3Page, onParis4Page, onParis5Page, onParis6Page, onParis7Page, onParis8Page, onParis9Page }) => {
+const SEOPage: React.FC<SEOPageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, arrondissementLinks}) => {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -482,17 +474,7 @@ const SEOPage: React.FC<SEOPageProps> = ({ onBack, onQuoteRequest, onPhotoboothD
       <Footer
         onSEOPage={onBack}
         onPhotoboothDetails={onPhotoboothDetails}
-        arrondissementLinks={[
-          { label: 'Location photobooth Paris 1', onClick: onParis1Page },
-          { label: 'Location photobooth Paris 2', onClick: onParis2Page },
-          { label: 'Location photobooth Paris 3', onClick: onParis3Page },
-          { label: 'Location photobooth Paris 4', onClick: onParis4Page },
-          { label: 'Location photobooth Paris 5', onClick: onParis5Page },
-          { label: 'Location photobooth Paris 6', onClick: onParis6Page },
-          { label: 'Location photobooth Paris 7', onClick: onParis7Page },
-          { label: 'Location photobooth Paris 8', onClick: onParis8Page },
-          { label: 'Location photobooth Paris 9', onClick: onParis9Page },
-        ]}
+        arrondissementLinks={arrondissementLinks}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- add goToParisPage navigation helper and generate arrondissement links
- streamline arrondissement pages to use shared arrondissementLinks prop

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6d1dbb0e4833185d028c0be9ff6c1