### PR TITLE
feat: centralize navigation menu

### DIFF
--- a/src/components/AIAnimationsPage.tsx
+++ b/src/components/AIAnimationsPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   ArrowLeft,
   Camera,
@@ -20,8 +20,8 @@ import {
   Timer,
   Trophy
 } from 'lucide-react';
-import HomeSectionLink from './HomeSectionLink';
 import Footer from './Footer';
+import NavigationMenu, { NavigationCallbacks } from './NavigationMenu';
 
 interface AIAnimationsPageProps {
   onBack: () => void;
@@ -32,7 +32,25 @@ interface AIAnimationsPageProps {
   onQuoteRequest?: () => void;
 }
 
-const AIAnimationsPage: React.FC<AIAnimationsPageProps> = ({ onBack, onDemoRequest, onPhotoboothDetails, onSEOPage, onQuoteRequest , arrondissementLinks }) => {
+const AIAnimationsPage: React.FC<AIAnimationsPageProps> = ({
+  onBack,
+  onDemoRequest,
+  onPhotoboothDetails,
+  onSEOPage,
+  onQuoteRequest,
+  arrondissementLinks,
+}) => {
+  const navigationCallbacks = useMemo<NavigationCallbacks>(
+    () => ({
+      '/': onBack,
+      ...((onPhotoboothDetails || onBack)
+        ? { '/location-photobooth-paris': onPhotoboothDetails || onBack }
+        : {}),
+      ...(onQuoteRequest ? { '/devis-photobooth-gratuit': onQuoteRequest } : {}),
+    }),
+    [onBack, onPhotoboothDetails, onQuoteRequest],
+  );
+
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -46,31 +64,7 @@ const AIAnimationsPage: React.FC<AIAnimationsPageProps> = ({ onBack, onDemoReque
               <span className="text-2xl font-bold text-black">BoostPix</span>
             </div>
 
-            <nav className="hidden lg:flex items-center space-x-8">
-              <button 
-                onClick={onBack}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Accueil
-              </button>
-              <button 
-                onClick={onPhotoboothDetails || onBack}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Photobooth sur mesure
-              </button>
-              <HomeSectionLink label="Événements Privés" targetId="mariages" onBack={onBack} />
-              <span className="text-yellow-500 font-medium cursor-default">
-                Animations IA
-              </span>
-              <HomeSectionLink label="Galerie" targetId="galerie" onBack={onBack} />
-              <button 
-                onClick={onQuoteRequest}
-                className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
-              >
-                Devis Gratuit
-              </button>
-            </nav>
+            <NavigationMenu className="hidden lg:flex" onNavigate={navigationCallbacks} />
 
             <button 
               onClick={onBack}

--- a/src/components/ArrondissementPageLayout.tsx
+++ b/src/components/ArrondissementPageLayout.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { ArrowLeft, Camera } from 'lucide-react';
-import HomeSectionLink from './HomeSectionLink';
 import Footer from './Footer';
+import NavigationMenu, { NavigationCallbacks } from './NavigationMenu';
 
 interface ArrondissementLink {
   label: string;
@@ -31,6 +31,16 @@ const ArrondissementPageLayout: React.FC<ArrondissementPageLayoutProps> = ({
 }) => {
   const arrondissementLabel = arrondissement === 1 ? '1er' : `${arrondissement}ème`;
 
+  const navigationCallbacks = useMemo<NavigationCallbacks>(
+    () => ({
+      '/': onBack,
+      ...(onPhotoboothDetails ? { '/location-photobooth-paris': onPhotoboothDetails } : {}),
+      ...(onAIAnimations ? { '/animations-photobooth-ia': onAIAnimations } : {}),
+      ...(onQuoteRequest ? { '/devis-photobooth-gratuit': onQuoteRequest } : {}),
+    }),
+    [onAIAnimations, onBack, onPhotoboothDetails, onQuoteRequest],
+  );
+
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -44,31 +54,7 @@ const ArrondissementPageLayout: React.FC<ArrondissementPageLayoutProps> = ({
               <span className="text-2xl font-bold text-black">BoostPix</span>
             </div>
 
-            <nav className="hidden lg:flex items-center space-x-8">
-              <button onClick={onBack} className="text-gray-700 hover:text-yellow-500 transition-colors font-medium">
-                Accueil
-              </button>
-              <button
-                onClick={onPhotoboothDetails}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Photobooth sur mesure
-              </button>
-              <HomeSectionLink label="Événements Privés" targetId="mariages" onBack={onBack} />
-              <button
-                onClick={onAIAnimations}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Animations IA
-              </button>
-              <HomeSectionLink label="Galerie" targetId="galerie" onBack={onBack} />
-              <button
-                onClick={onQuoteRequest}
-                className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
-              >
-                Devis Gratuit
-              </button>
-            </nav>
+            <NavigationMenu className="hidden lg:flex" onNavigate={navigationCallbacks} />
 
             <button
               onClick={onBack}

--- a/src/components/DemoRequestPage.tsx
+++ b/src/components/DemoRequestPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   ArrowLeft,
   Camera,
@@ -14,8 +14,8 @@ import {
   Mail,
   User
 } from 'lucide-react';
-import HomeSectionLink from './HomeSectionLink';
 import Footer from './Footer';
+import NavigationMenu, { NavigationCallbacks } from './NavigationMenu';
 
 interface DemoRequestPageProps {
   onBack: () => void;
@@ -24,7 +24,7 @@ interface DemoRequestPageProps {
   onQuoteRequest?: () => void;
 }
 
-const DemoRequestPage: React.FC<DemoRequestPageProps> = ({ onBack, onSEOPage, onQuoteRequest , arrondissementLinks }) => {
+const DemoRequestPage: React.FC<DemoRequestPageProps> = ({ onBack, onSEOPage, onQuoteRequest, arrondissementLinks }) => {
   const [currentStep, setCurrentStep] = useState(1);
   const [formData, setFormData] = useState({
     demoType: '', // 'live' or 'video'
@@ -74,6 +74,14 @@ const DemoRequestPage: React.FC<DemoRequestPageProps> = ({ onBack, onSEOPage, on
     setCurrentStep(3);
   };
 
+  const navigationCallbacks = useMemo<NavigationCallbacks>(
+    () => ({
+      '/': onBack,
+      ...(onQuoteRequest ? { '/devis-photobooth-gratuit': onQuoteRequest } : {}),
+    }),
+    [onBack, onQuoteRequest],
+  );
+
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
@@ -87,34 +95,7 @@ const DemoRequestPage: React.FC<DemoRequestPageProps> = ({ onBack, onSEOPage, on
               <span className="text-2xl font-bold text-black">BoostPix</span>
             </div>
 
-            <nav className="hidden lg:flex items-center space-x-8">
-              <button 
-                onClick={onBack}
-               className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-               Accueil
-              </button>
-              <button 
-                onClick={onBack}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Photobooth sur mesure
-              </button>
-              <HomeSectionLink label="Événements Privés" targetId="mariages" onBack={onBack} />
-              <button 
-                onClick={onBack}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Animations IA
-              </button>
-              <HomeSectionLink label="Galerie" targetId="galerie" onBack={onBack} />
-              <button 
-                onClick={onQuoteRequest}
-                className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
-              >
-                Devis Gratuit
-              </button>
-            </nav>
+            <NavigationMenu className="hidden lg:flex" onNavigate={navigationCallbacks} />
 
             <button 
               onClick={onBack}

--- a/src/components/GalleryPage.tsx
+++ b/src/components/GalleryPage.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Camera, Star } from 'lucide-react';
 import Footer from './Footer';
+import NavigationMenu, { NavigationCallbacks } from './NavigationMenu';
 
 interface GalleryPageProps {
   onBack: () => void;
@@ -17,6 +18,15 @@ const GalleryPage: React.FC<GalleryPageProps> = ({
   onSEOPage,
   arrondissementLinks,
 }) => {
+  const navigationCallbacks = useMemo<NavigationCallbacks>(
+    () => ({
+      ...(onBack ? { '/': onBack } : {}),
+      ...(onPhotoboothDetails ? { '/location-photobooth-paris': onPhotoboothDetails } : {}),
+      ...(onQuoteRequest ? { '/devis-photobooth-gratuit': onQuoteRequest } : {}),
+    }),
+    [onBack, onPhotoboothDetails, onQuoteRequest],
+  );
+
   const photos = [
     {
       src: 'https://res.cloudinary.com/de55ql9ig/image/upload/v1755162724/_DSC5745-Modifier_iyfv38.jpg',
@@ -64,17 +74,7 @@ const GalleryPage: React.FC<GalleryPageProps> = ({
               <span className="text-2xl font-bold text-black">BoostPix</span>
             </div>
 
-            <nav className="hidden lg:flex items-center space-x-8">
-              <button onClick={onBack} className="text-gray-700 hover:text-yellow-500 transition-colors font-medium">
-                Accueil
-              </button>
-              <button onClick={onPhotoboothDetails} className="text-gray-700 hover:text-yellow-500 transition-colors font-medium">
-                Photobooth sur mesure
-              </button>
-              <button onClick={onQuoteRequest} className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold">
-                Devis Gratuit
-              </button>
-            </nav>
+            <NavigationMenu className="hidden lg:flex" onNavigate={navigationCallbacks} />
           </div>
         </div>
       </header>

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   Camera,
   Sparkles,
@@ -12,6 +12,7 @@ import {
   Check,
 } from 'lucide-react';
 import Footer from './Footer';
+import NavigationMenu, { NavigationCallbacks } from './NavigationMenu';
 import { useRouter } from '../router';
 import { ARRONDISSEMENTS } from '../data/arrondissements';
 
@@ -28,10 +29,26 @@ const HomePage: React.FC = () => {
     [navigate],
   );
 
-  const handleNavigate = (path: string) => {
-    setIsMenuOpen(false);
-    navigate(path);
-  };
+  const handleNavigate = useCallback(
+    (path: string) => {
+      setIsMenuOpen(false);
+      navigate(path);
+    },
+    [navigate],
+  );
+
+  const navigationCallbacks = useMemo<NavigationCallbacks>(
+    () => ({
+      '/': () => handleNavigate('/'),
+      '/services': () => handleNavigate('/services'),
+      '/location-photobooth-paris': () => handleNavigate('/location-photobooth-paris'),
+      '/photobooth-evenement-paris': () => handleNavigate('/photobooth-evenement-paris'),
+      '/animations-photobooth-ia': () => handleNavigate('/animations-photobooth-ia'),
+      '/galerie-photobooth-paris': () => handleNavigate('/galerie-photobooth-paris'),
+      '/devis-photobooth-gratuit': () => handleNavigate('/devis-photobooth-gratuit'),
+    }),
+    [handleNavigate],
+  );
 
   return (
     <div className="min-h-screen bg-white">
@@ -46,50 +63,11 @@ const HomePage: React.FC = () => {
               <span className="text-2xl font-bold text-black">BoostPix</span>
             </div>
 
-            <nav className="hidden lg:flex items-center space-x-8" role="navigation" aria-label="Navigation principale">
-              <button
-                onClick={() => handleNavigate('/')}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Accueil
-              </button>
-              <button
-                onClick={() => handleNavigate('/services')}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Services
-              </button>
-              <button
-                onClick={() => handleNavigate('/location-photobooth-paris')}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Photobooth sur mesure
-              </button>
-              <button
-                onClick={() => handleNavigate('/photobooth-evenement-paris')}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Événements Privés
-              </button>
-              <button
-                onClick={() => handleNavigate('/animations-photobooth-ia')}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Animations IA
-              </button>
-              <button
-                onClick={() => handleNavigate('/galerie-photobooth-paris')}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Galerie
-              </button>
-              <button
-                onClick={() => handleNavigate('/devis-photobooth-gratuit')}
-                className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
-              >
-                Devis Gratuit
-              </button>
-            </nav>
+            <NavigationMenu
+              className="hidden lg:flex"
+              aria-label="Navigation principale"
+              onNavigate={navigationCallbacks}
+            />
 
             <button className="lg:hidden" onClick={() => setIsMenuOpen(!isMenuOpen)} aria-label="Ouvrir le menu">
               {isMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
@@ -99,50 +77,12 @@ const HomePage: React.FC = () => {
           {/* Mobile Menu */}
           {isMenuOpen && (
             <div className="lg:hidden mt-4 pb-4 border-t border-gray-100">
-              <div className="flex flex-col space-y-4 pt-4">
-                <button
-                  onClick={() => handleNavigate('/')}
-                  className="text-gray-700 hover:text-yellow-500 transition-colors font-medium text-left"
-                >
-                  Accueil
-                </button>
-                <button
-                  onClick={() => handleNavigate('/services')}
-                  className="text-gray-700 hover:text-yellow-500 transition-colors font-medium text-left"
-                >
-                  Services
-                </button>
-                <button
-                  onClick={() => handleNavigate('/location-photobooth-paris')}
-                  className="text-gray-700 hover:text-yellow-500 transition-colors font-medium text-left"
-                >
-                  Photobooth sur mesure
-                </button>
-                <button
-                  onClick={() => handleNavigate('/photobooth-evenement-paris')}
-                  className="text-gray-700 hover:text-yellow-500 transition-colors font-medium text-left"
-                >
-                  Événements Privés
-                </button>
-                <button
-                  onClick={() => handleNavigate('/animations-photobooth-ia')}
-                  className="text-gray-700 hover:text-yellow-500 transition-colors font-medium text-left"
-                >
-                  Animations IA
-                </button>
-                <button
-                  onClick={() => handleNavigate('/galerie-photobooth-paris')}
-                  className="text-gray-700 hover:text-yellow-500 transition-colors font-medium text-left"
-                >
-                  Galerie
-                </button>
-                <button
-                  onClick={() => handleNavigate('/devis-photobooth-gratuit')}
-                  className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold text-center"
-                >
-                  Devis Gratuit
-                </button>
-              </div>
+              <NavigationMenu
+                layout="vertical"
+                className="pt-4"
+                onNavigate={navigationCallbacks}
+                onItemClick={() => setIsMenuOpen(false)}
+              />
             </div>
           )}
         </div>

--- a/src/components/NavigationMenu.tsx
+++ b/src/components/NavigationMenu.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { useRouter } from '../router';
+
+type NavigationItem = {
+  path: NavigationPath;
+  label: string;
+  isPrimary?: boolean;
+};
+
+export type NavigationPath =
+  | '/'
+  | '/services'
+  | '/location-photobooth-paris'
+  | '/photobooth-evenement-paris'
+  | '/animations-photobooth-ia'
+  | '/galerie-photobooth-paris'
+  | '/devis-photobooth-gratuit';
+
+const NAVIGATION_ITEMS: readonly NavigationItem[] = [
+  { path: '/', label: 'Accueil' },
+  { path: '/services', label: 'Services' },
+  { path: '/location-photobooth-paris', label: 'Photobooth sur mesure' },
+  { path: '/photobooth-evenement-paris', label: 'Événements Privés' },
+  { path: '/animations-photobooth-ia', label: 'Animations IA' },
+  { path: '/galerie-photobooth-paris', label: 'Galerie' },
+  { path: '/devis-photobooth-gratuit', label: 'Devis Gratuit', isPrimary: true },
+];
+
+export type NavigationCallbacks = Partial<Record<NavigationPath, () => void>>;
+
+export interface NavigationMenuProps extends React.HTMLAttributes<HTMLElement> {
+  layout?: 'horizontal' | 'vertical';
+  onNavigate?: NavigationCallbacks;
+  onItemClick?: () => void;
+}
+
+const NavigationMenu: React.FC<NavigationMenuProps> = ({
+  layout = 'horizontal',
+  className = '',
+  onNavigate,
+  onItemClick,
+  ...rest
+}) => {
+  const { path: currentPath, navigate } = useRouter();
+
+  const containerClassName = [
+    layout === 'vertical' ? 'flex flex-col space-y-4' : 'flex items-center space-x-8',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <nav className={containerClassName} {...rest}>
+      {NAVIGATION_ITEMS.map(item => {
+        const isActive = currentPath === item.path;
+        const baseClassName = item.isPrimary
+          ? layout === 'vertical'
+            ? 'bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold text-center'
+            : 'bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold'
+          : layout === 'vertical'
+            ? 'text-left text-gray-700 hover:text-yellow-500 transition-colors font-medium'
+            : 'text-gray-700 hover:text-yellow-500 transition-colors font-medium';
+        const activeClassName = item.isPrimary ? 'bg-yellow-500 text-black' : 'text-yellow-500';
+        const classNames = [baseClassName, isActive ? `${activeClassName} cursor-default` : undefined]
+          .filter(Boolean)
+          .join(' ');
+
+        const handleClick = () => {
+          if (isActive) {
+            onItemClick?.();
+            return;
+          }
+
+          const callback = onNavigate?.[item.path];
+          if (callback) {
+            callback();
+          } else {
+            navigate(item.path);
+          }
+
+          onItemClick?.();
+        };
+
+        return (
+          <button
+            key={item.path}
+            type="button"
+            onClick={handleClick}
+            className={classNames}
+            aria-current={isActive ? 'page' : undefined}
+          >
+            {item.label}
+          </button>
+        );
+      })}
+    </nav>
+  );
+};
+
+export default NavigationMenu;

--- a/src/components/Paris10Page.tsx
+++ b/src/components/Paris10Page.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   ArrowLeft,
   Camera,
@@ -7,8 +7,8 @@ import {
   Share2,
   Settings,
 } from 'lucide-react';
-import HomeSectionLink from './HomeSectionLink';
 import Footer from './Footer';
+import NavigationMenu, { NavigationCallbacks } from './NavigationMenu';
 
 interface Paris10PageProps {
   onBack: () => void;
@@ -24,7 +24,19 @@ const Paris10Page: React.FC<Paris10PageProps> = ({
   onQuoteRequest,
   onPhotoboothDetails,
   onAIAnimations,
-  onSEOPage, arrondissementLinks }) => {
+  onSEOPage,
+  arrondissementLinks,
+}) => {
+  const navigationCallbacks = useMemo<NavigationCallbacks>(
+    () => ({
+      '/': onBack,
+      ...(onPhotoboothDetails ? { '/location-photobooth-paris': onPhotoboothDetails } : {}),
+      ...(onAIAnimations ? { '/animations-photobooth-ia': onAIAnimations } : {}),
+      ...(onQuoteRequest ? { '/devis-photobooth-gratuit': onQuoteRequest } : {}),
+    }),
+    [onAIAnimations, onBack, onPhotoboothDetails, onQuoteRequest],
+  );
+
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -38,34 +50,7 @@ const Paris10Page: React.FC<Paris10PageProps> = ({
               <span className="text-2xl font-bold text-black">BoostPix</span>
             </div>
 
-            <nav className="hidden lg:flex items-center space-x-8">
-              <button
-                onClick={onBack}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Accueil
-              </button>
-              <button
-                onClick={onPhotoboothDetails}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Photobooth sur mesure
-              </button>
-              <HomeSectionLink label="Événements Privés" targetId="mariages" onBack={onBack} />
-              <button
-                onClick={onAIAnimations}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Animations IA
-              </button>
-              <HomeSectionLink label="Galerie" targetId="galerie" onBack={onBack} />
-              <button
-                onClick={onQuoteRequest}
-                className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
-              >
-                Devis Gratuit
-              </button>
-            </nav>
+            <NavigationMenu className="hidden lg:flex" onNavigate={navigationCallbacks} />
 
             <button
               onClick={onBack}

--- a/src/components/Paris11Page.tsx
+++ b/src/components/Paris11Page.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   ArrowLeft,
   Camera,
@@ -11,8 +11,8 @@ import {
   Sparkles,
   Share2
 } from 'lucide-react';
-import HomeSectionLink from './HomeSectionLink';
 import Footer from './Footer';
+import NavigationMenu, { NavigationCallbacks } from './NavigationMenu';
 
 interface Paris11PageProps {
   onBack: () => void;
@@ -28,7 +28,19 @@ const Paris11Page: React.FC<Paris11PageProps> = ({
   onQuoteRequest,
   onPhotoboothDetails,
   onAIAnimations,
-  onSEOPage, arrondissementLinks }) => {
+  onSEOPage,
+  arrondissementLinks,
+}) => {
+  const navigationCallbacks = useMemo<NavigationCallbacks>(
+    () => ({
+      '/': onBack,
+      ...(onPhotoboothDetails ? { '/location-photobooth-paris': onPhotoboothDetails } : {}),
+      ...(onAIAnimations ? { '/animations-photobooth-ia': onAIAnimations } : {}),
+      ...(onQuoteRequest ? { '/devis-photobooth-gratuit': onQuoteRequest } : {}),
+    }),
+    [onAIAnimations, onBack, onPhotoboothDetails, onQuoteRequest],
+  );
+
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -42,34 +54,7 @@ const Paris11Page: React.FC<Paris11PageProps> = ({
               <span className="text-2xl font-bold text-black">BoostPix</span>
             </div>
 
-            <nav className="hidden lg:flex items-center space-x-8">
-              <button
-                onClick={onBack}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Accueil
-              </button>
-              <button
-                onClick={onPhotoboothDetails}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Photobooth sur mesure
-              </button>
-              <HomeSectionLink label="Événements Privés" targetId="mariages" onBack={onBack} />
-              <button
-                onClick={onAIAnimations}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Animations IA
-              </button>
-              <HomeSectionLink label="Galerie" targetId="galerie" onBack={onBack} />
-              <button
-                onClick={onQuoteRequest}
-                className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
-              >
-                Devis Gratuit
-              </button>
-            </nav>
+            <NavigationMenu className="hidden lg:flex" onNavigate={navigationCallbacks} />
 
             <button
               onClick={onBack}

--- a/src/components/Paris12Page.tsx
+++ b/src/components/Paris12Page.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   ArrowLeft,
   Camera,
@@ -8,8 +8,8 @@ import {
   Award,
   Palette,
 } from 'lucide-react';
-import HomeSectionLink from './HomeSectionLink';
 import Footer from './Footer';
+import NavigationMenu, { NavigationCallbacks } from './NavigationMenu';
 
 interface Paris12PageProps {
   onBack: () => void;
@@ -25,7 +25,19 @@ const Paris12Page: React.FC<Paris12PageProps> = ({
   onQuoteRequest,
   onPhotoboothDetails,
   onAIAnimations,
-  onSEOPage, arrondissementLinks }) => {
+  onSEOPage,
+  arrondissementLinks,
+}) => {
+  const navigationCallbacks = useMemo<NavigationCallbacks>(
+    () => ({
+      '/': onBack,
+      ...(onPhotoboothDetails ? { '/location-photobooth-paris': onPhotoboothDetails } : {}),
+      ...(onAIAnimations ? { '/animations-photobooth-ia': onAIAnimations } : {}),
+      ...(onQuoteRequest ? { '/devis-photobooth-gratuit': onQuoteRequest } : {}),
+    }),
+    [onAIAnimations, onBack, onPhotoboothDetails, onQuoteRequest],
+  );
+
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -39,34 +51,7 @@ const Paris12Page: React.FC<Paris12PageProps> = ({
               <span className="text-2xl font-bold text-black">BoostPix</span>
             </div>
 
-            <nav className="hidden lg:flex items-center space-x-8">
-              <button
-                onClick={onBack}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Accueil
-              </button>
-              <button
-                onClick={onPhotoboothDetails}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Photobooth sur mesure
-              </button>
-              <HomeSectionLink label="Événements Privés" targetId="mariages" onBack={onBack} />
-              <button
-                onClick={onAIAnimations}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Animations IA
-              </button>
-              <HomeSectionLink label="Galerie" targetId="galerie" onBack={onBack} />
-              <button
-                onClick={onQuoteRequest}
-                className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
-              >
-                Devis Gratuit
-              </button>
-            </nav>
+            <NavigationMenu className="hidden lg:flex" onNavigate={navigationCallbacks} />
 
             <button
               onClick={onBack}

--- a/src/components/Paris1Page.tsx
+++ b/src/components/Paris1Page.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   ArrowLeft,
   Camera,
@@ -10,8 +10,8 @@ import {
   Award,
   Settings
 } from 'lucide-react';
-import HomeSectionLink from './HomeSectionLink';
 import Footer from './Footer';
+import NavigationMenu, { NavigationCallbacks } from './NavigationMenu';
 
 interface Paris1PageProps {
   onBack: () => void;
@@ -22,7 +22,24 @@ interface Paris1PageProps {
   arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
-const Paris1Page: React.FC<Paris1PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, arrondissementLinks }) => {
+const Paris1Page: React.FC<Paris1PageProps> = ({
+  onBack,
+  onQuoteRequest,
+  onPhotoboothDetails,
+  onAIAnimations,
+  onSEOPage,
+  arrondissementLinks,
+}) => {
+  const navigationCallbacks = useMemo<NavigationCallbacks>(
+    () => ({
+      '/': onBack,
+      ...(onPhotoboothDetails ? { '/location-photobooth-paris': onPhotoboothDetails } : {}),
+      ...(onAIAnimations ? { '/animations-photobooth-ia': onAIAnimations } : {}),
+      ...(onQuoteRequest ? { '/devis-photobooth-gratuit': onQuoteRequest } : {}),
+    }),
+    [onAIAnimations, onBack, onPhotoboothDetails, onQuoteRequest],
+  );
+
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -36,34 +53,7 @@ const Paris1Page: React.FC<Paris1PageProps> = ({ onBack, onQuoteRequest, onPhoto
               <span className="text-2xl font-bold text-black">BoostPix</span>
             </div>
 
-            <nav className="hidden lg:flex items-center space-x-8">
-              <button 
-                onClick={onBack}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Accueil
-              </button>
-              <button 
-                onClick={onPhotoboothDetails}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Photobooth sur mesure
-              </button>
-              <HomeSectionLink label="Événements Privés" targetId="mariages" onBack={onBack} />
-              <button 
-                onClick={onAIAnimations}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Animations IA
-              </button>
-              <HomeSectionLink label="Galerie" targetId="galerie" onBack={onBack} />
-              <button 
-                onClick={onQuoteRequest}
-                className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
-              >
-                Devis Gratuit
-              </button>
-            </nav>
+            <NavigationMenu className="hidden lg:flex" onNavigate={navigationCallbacks} />
 
             <button 
               onClick={onBack}

--- a/src/components/Paris2Page.tsx
+++ b/src/components/Paris2Page.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   ArrowLeft,
   Camera,
@@ -8,8 +8,8 @@ import {
   Award,
   Zap
 } from 'lucide-react';
-import HomeSectionLink from './HomeSectionLink';
 import Footer from './Footer';
+import NavigationMenu, { NavigationCallbacks } from './NavigationMenu';
 
 interface Paris2PageProps {
   onBack: () => void;
@@ -20,7 +20,24 @@ interface Paris2PageProps {
   arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
-const Paris2Page: React.FC<Paris2PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, arrondissementLinks }) => {
+const Paris2Page: React.FC<Paris2PageProps> = ({
+  onBack,
+  onQuoteRequest,
+  onPhotoboothDetails,
+  onAIAnimations,
+  onSEOPage,
+  arrondissementLinks,
+}) => {
+  const navigationCallbacks = useMemo<NavigationCallbacks>(
+    () => ({
+      '/': onBack,
+      ...(onPhotoboothDetails ? { '/location-photobooth-paris': onPhotoboothDetails } : {}),
+      ...(onAIAnimations ? { '/animations-photobooth-ia': onAIAnimations } : {}),
+      ...(onQuoteRequest ? { '/devis-photobooth-gratuit': onQuoteRequest } : {}),
+    }),
+    [onAIAnimations, onBack, onPhotoboothDetails, onQuoteRequest],
+  );
+
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -34,34 +51,7 @@ const Paris2Page: React.FC<Paris2PageProps> = ({ onBack, onQuoteRequest, onPhoto
               <span className="text-2xl font-bold text-black">BoostPix</span>
             </div>
 
-            <nav className="hidden lg:flex items-center space-x-8">
-              <button 
-                onClick={onBack}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Accueil
-              </button>
-              <button 
-                onClick={onPhotoboothDetails}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Photobooth sur mesure
-              </button>
-              <HomeSectionLink label="Événements Privés" targetId="mariages" onBack={onBack} />
-              <button 
-                onClick={onAIAnimations}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Animations IA
-              </button>
-              <HomeSectionLink label="Galerie" targetId="galerie" onBack={onBack} />
-              <button 
-                onClick={onQuoteRequest}
-                className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
-              >
-                Devis Gratuit
-              </button>
-            </nav>
+            <NavigationMenu className="hidden lg:flex" onNavigate={navigationCallbacks} />
 
             <button 
               onClick={onBack}

--- a/src/components/Paris3Page.tsx
+++ b/src/components/Paris3Page.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   ArrowLeft,
   Camera,
@@ -10,8 +10,8 @@ import {
   Shield,
   Settings
 } from 'lucide-react';
-import HomeSectionLink from './HomeSectionLink';
 import Footer from './Footer';
+import NavigationMenu, { NavigationCallbacks } from './NavigationMenu';
 
 interface Paris3PageProps {
   onBack: () => void;
@@ -22,7 +22,24 @@ interface Paris3PageProps {
   arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
-const Paris3Page: React.FC<Paris3PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, arrondissementLinks }) => {
+const Paris3Page: React.FC<Paris3PageProps> = ({
+  onBack,
+  onQuoteRequest,
+  onPhotoboothDetails,
+  onAIAnimations,
+  onSEOPage,
+  arrondissementLinks,
+}) => {
+  const navigationCallbacks = useMemo<NavigationCallbacks>(
+    () => ({
+      '/': onBack,
+      ...(onPhotoboothDetails ? { '/location-photobooth-paris': onPhotoboothDetails } : {}),
+      ...(onAIAnimations ? { '/animations-photobooth-ia': onAIAnimations } : {}),
+      ...(onQuoteRequest ? { '/devis-photobooth-gratuit': onQuoteRequest } : {}),
+    }),
+    [onAIAnimations, onBack, onPhotoboothDetails, onQuoteRequest],
+  );
+
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -36,34 +53,7 @@ const Paris3Page: React.FC<Paris3PageProps> = ({ onBack, onQuoteRequest, onPhoto
               <span className="text-2xl font-bold text-black">BoostPix</span>
             </div>
 
-            <nav className="hidden lg:flex items-center space-x-8">
-              <button 
-                onClick={onBack}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Accueil
-              </button>
-              <button 
-                onClick={onPhotoboothDetails}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Photobooth sur mesure
-              </button>
-              <HomeSectionLink label="Événements Privés" targetId="mariages" onBack={onBack} />
-              <button 
-                onClick={onAIAnimations}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Animations IA
-              </button>
-              <HomeSectionLink label="Galerie" targetId="galerie" onBack={onBack} />
-              <button 
-                onClick={onQuoteRequest}
-                className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
-              >
-                Devis Gratuit
-              </button>
-            </nav>
+            <NavigationMenu className="hidden lg:flex" onNavigate={navigationCallbacks} />
 
             <button 
               onClick={onBack}

--- a/src/components/Paris4Page.tsx
+++ b/src/components/Paris4Page.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   ArrowLeft,
   Camera,
@@ -10,8 +10,8 @@ import {
   Shield,
   Settings
 } from 'lucide-react';
-import HomeSectionLink from './HomeSectionLink';
 import Footer from './Footer';
+import NavigationMenu, { NavigationCallbacks } from './NavigationMenu';
 
 interface Paris4PageProps {
   onBack: () => void;
@@ -22,7 +22,24 @@ interface Paris4PageProps {
   arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
-const Paris4Page: React.FC<Paris4PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, arrondissementLinks }) => {
+const Paris4Page: React.FC<Paris4PageProps> = ({
+  onBack,
+  onQuoteRequest,
+  onPhotoboothDetails,
+  onAIAnimations,
+  onSEOPage,
+  arrondissementLinks,
+}) => {
+  const navigationCallbacks = useMemo<NavigationCallbacks>(
+    () => ({
+      '/': onBack,
+      ...(onPhotoboothDetails ? { '/location-photobooth-paris': onPhotoboothDetails } : {}),
+      ...(onAIAnimations ? { '/animations-photobooth-ia': onAIAnimations } : {}),
+      ...(onQuoteRequest ? { '/devis-photobooth-gratuit': onQuoteRequest } : {}),
+    }),
+    [onAIAnimations, onBack, onPhotoboothDetails, onQuoteRequest],
+  );
+
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -36,34 +53,7 @@ const Paris4Page: React.FC<Paris4PageProps> = ({ onBack, onQuoteRequest, onPhoto
               <span className="text-2xl font-bold text-black">BoostPix</span>
             </div>
 
-            <nav className="hidden lg:flex items-center space-x-8">
-              <button 
-                onClick={onBack}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Accueil
-              </button>
-              <button 
-                onClick={onPhotoboothDetails}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Photobooth sur mesure
-              </button>
-              <HomeSectionLink label="Événements Privés" targetId="mariages" onBack={onBack} />
-              <button 
-                onClick={onAIAnimations}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Animations IA
-              </button>
-              <HomeSectionLink label="Galerie" targetId="galerie" onBack={onBack} />
-              <button 
-                onClick={onQuoteRequest}
-                className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
-              >
-                Devis Gratuit
-              </button>
-            </nav>
+            <NavigationMenu className="hidden lg:flex" onNavigate={navigationCallbacks} />
 
             <button 
               onClick={onBack}

--- a/src/components/Paris5Page.tsx
+++ b/src/components/Paris5Page.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   ArrowLeft,
   Camera,
@@ -11,8 +11,8 @@ import {
   Eye,
   Settings
 } from 'lucide-react';
-import HomeSectionLink from './HomeSectionLink';
 import Footer from './Footer';
+import NavigationMenu, { NavigationCallbacks } from './NavigationMenu';
 
 interface Paris5PageProps {
   onBack: () => void;
@@ -23,7 +23,24 @@ interface Paris5PageProps {
   arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
-const Paris5Page: React.FC<Paris5PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, arrondissementLinks }) => {
+const Paris5Page: React.FC<Paris5PageProps> = ({
+  onBack,
+  onQuoteRequest,
+  onPhotoboothDetails,
+  onAIAnimations,
+  onSEOPage,
+  arrondissementLinks,
+}) => {
+  const navigationCallbacks = useMemo<NavigationCallbacks>(
+    () => ({
+      '/': onBack,
+      ...(onPhotoboothDetails ? { '/location-photobooth-paris': onPhotoboothDetails } : {}),
+      ...(onAIAnimations ? { '/animations-photobooth-ia': onAIAnimations } : {}),
+      ...(onQuoteRequest ? { '/devis-photobooth-gratuit': onQuoteRequest } : {}),
+    }),
+    [onAIAnimations, onBack, onPhotoboothDetails, onQuoteRequest],
+  );
+
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -37,34 +54,7 @@ const Paris5Page: React.FC<Paris5PageProps> = ({ onBack, onQuoteRequest, onPhoto
               <span className="text-2xl font-bold text-black">BoostPix</span>
             </div>
 
-            <nav className="hidden lg:flex items-center space-x-8">
-              <button 
-                onClick={onBack}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Accueil
-              </button>
-              <button 
-                onClick={onPhotoboothDetails}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Photobooth sur mesure
-              </button>
-              <HomeSectionLink label="Événements Privés" targetId="mariages" onBack={onBack} />
-              <button 
-                onClick={onAIAnimations}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Animations IA
-              </button>
-              <HomeSectionLink label="Galerie" targetId="galerie" onBack={onBack} />
-              <button 
-                onClick={onQuoteRequest}
-                className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
-              >
-                Devis Gratuit
-              </button>
-            </nav>
+            <NavigationMenu className="hidden lg:flex" onNavigate={navigationCallbacks} />
 
             <button 
               onClick={onBack}

--- a/src/components/Paris6Page.tsx
+++ b/src/components/Paris6Page.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   ArrowLeft,
   Camera,
@@ -13,8 +13,8 @@ import {
   Smartphone,
   Monitor
 } from 'lucide-react';
-import HomeSectionLink from './HomeSectionLink';
 import Footer from './Footer';
+import NavigationMenu, { NavigationCallbacks } from './NavigationMenu';
 
 interface Paris6PageProps {
   onBack: () => void;
@@ -25,7 +25,24 @@ interface Paris6PageProps {
   arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
-const Paris6Page: React.FC<Paris6PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, arrondissementLinks }) => {
+const Paris6Page: React.FC<Paris6PageProps> = ({
+  onBack,
+  onQuoteRequest,
+  onPhotoboothDetails,
+  onAIAnimations,
+  onSEOPage,
+  arrondissementLinks,
+}) => {
+  const navigationCallbacks = useMemo<NavigationCallbacks>(
+    () => ({
+      '/': onBack,
+      ...(onPhotoboothDetails ? { '/location-photobooth-paris': onPhotoboothDetails } : {}),
+      ...(onAIAnimations ? { '/animations-photobooth-ia': onAIAnimations } : {}),
+      ...(onQuoteRequest ? { '/devis-photobooth-gratuit': onQuoteRequest } : {}),
+    }),
+    [onAIAnimations, onBack, onPhotoboothDetails, onQuoteRequest],
+  );
+
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -39,34 +56,7 @@ const Paris6Page: React.FC<Paris6PageProps> = ({ onBack, onQuoteRequest, onPhoto
               <span className="text-2xl font-bold text-black">BoostPix</span>
             </div>
 
-            <nav className="hidden lg:flex items-center space-x-8">
-              <button 
-                onClick={onBack}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Accueil
-              </button>
-              <button 
-                onClick={onPhotoboothDetails}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Photobooth sur mesure
-              </button>
-              <HomeSectionLink label="Événements Privés" targetId="mariages" onBack={onBack} />
-              <button 
-                onClick={onAIAnimations}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Animations IA
-              </button>
-              <HomeSectionLink label="Galerie" targetId="galerie" onBack={onBack} />
-              <button 
-                onClick={onQuoteRequest}
-                className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
-              >
-                Devis Gratuit
-              </button>
-            </nav>
+            <NavigationMenu className="hidden lg:flex" onNavigate={navigationCallbacks} />
 
             <button 
               onClick={onBack}

--- a/src/components/Paris7Page.tsx
+++ b/src/components/Paris7Page.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   ArrowLeft,
   Camera,
@@ -12,8 +12,8 @@ import {
   Settings,
   Monitor
 } from 'lucide-react';
-import HomeSectionLink from './HomeSectionLink';
 import Footer from './Footer';
+import NavigationMenu, { NavigationCallbacks } from './NavigationMenu';
 
 interface Paris7PageProps {
   onBack: () => void;
@@ -24,7 +24,24 @@ interface Paris7PageProps {
   arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
-const Paris7Page: React.FC<Paris7PageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, arrondissementLinks }) => {
+const Paris7Page: React.FC<Paris7PageProps> = ({
+  onBack,
+  onQuoteRequest,
+  onPhotoboothDetails,
+  onAIAnimations,
+  onSEOPage,
+  arrondissementLinks,
+}) => {
+  const navigationCallbacks = useMemo<NavigationCallbacks>(
+    () => ({
+      '/': onBack,
+      ...(onPhotoboothDetails ? { '/location-photobooth-paris': onPhotoboothDetails } : {}),
+      ...(onAIAnimations ? { '/animations-photobooth-ia': onAIAnimations } : {}),
+      ...(onQuoteRequest ? { '/devis-photobooth-gratuit': onQuoteRequest } : {}),
+    }),
+    [onAIAnimations, onBack, onPhotoboothDetails, onQuoteRequest],
+  );
+
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -38,34 +55,7 @@ const Paris7Page: React.FC<Paris7PageProps> = ({ onBack, onQuoteRequest, onPhoto
               <span className="text-2xl font-bold text-black">BoostPix</span>
             </div>
 
-            <nav className="hidden lg:flex items-center space-x-8">
-              <button 
-                onClick={onBack}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Accueil
-              </button>
-              <button 
-                onClick={onPhotoboothDetails}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Photobooth sur mesure
-              </button>
-              <HomeSectionLink label="Événements Privés" targetId="mariages" onBack={onBack} />
-              <button 
-                onClick={onAIAnimations}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Animations IA
-              </button>
-              <HomeSectionLink label="Galerie" targetId="galerie" onBack={onBack} />
-              <button 
-                onClick={onQuoteRequest}
-                className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
-              >
-                Devis Gratuit
-              </button>
-            </nav>
+            <NavigationMenu className="hidden lg:flex" onNavigate={navigationCallbacks} />
 
             <button 
               onClick={onBack}

--- a/src/components/Paris8Page.tsx
+++ b/src/components/Paris8Page.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   ArrowLeft,
   Camera,
@@ -12,8 +12,8 @@ import {
   Award,
   Monitor
 } from 'lucide-react';
-import HomeSectionLink from './HomeSectionLink';
 import Footer from './Footer';
+import NavigationMenu, { NavigationCallbacks } from './NavigationMenu';
 
 interface Paris8PageProps {
   onBack: () => void;
@@ -29,7 +29,19 @@ const Paris8Page: React.FC<Paris8PageProps> = ({
   onQuoteRequest,
   onPhotoboothDetails,
   onAIAnimations,
-  onSEOPage, arrondissementLinks }) => {
+  onSEOPage,
+  arrondissementLinks,
+}) => {
+  const navigationCallbacks = useMemo<NavigationCallbacks>(
+    () => ({
+      '/': onBack,
+      ...(onPhotoboothDetails ? { '/location-photobooth-paris': onPhotoboothDetails } : {}),
+      ...(onAIAnimations ? { '/animations-photobooth-ia': onAIAnimations } : {}),
+      ...(onQuoteRequest ? { '/devis-photobooth-gratuit': onQuoteRequest } : {}),
+    }),
+    [onAIAnimations, onBack, onPhotoboothDetails, onQuoteRequest],
+  );
+
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -43,34 +55,7 @@ const Paris8Page: React.FC<Paris8PageProps> = ({
               <span className="text-2xl font-bold text-black">BoostPix</span>
             </div>
 
-            <nav className="hidden lg:flex items-center space-x-8">
-              <button
-                onClick={onBack}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Accueil
-              </button>
-              <button
-                onClick={onPhotoboothDetails}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Photobooth sur mesure
-              </button>
-              <HomeSectionLink label="Événements Privés" targetId="mariages" onBack={onBack} />
-              <button
-                onClick={onAIAnimations}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Animations IA
-              </button>
-              <HomeSectionLink label="Galerie" targetId="galerie" onBack={onBack} />
-              <button
-                onClick={onQuoteRequest}
-                className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
-              >
-                Devis Gratuit
-              </button>
-            </nav>
+            <NavigationMenu className="hidden lg:flex" onNavigate={navigationCallbacks} />
 
             <button
               onClick={onBack}

--- a/src/components/Paris9Page.tsx
+++ b/src/components/Paris9Page.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   ArrowLeft,
   Camera,
@@ -11,8 +11,8 @@ import {
   Star,
   Monitor,
 } from 'lucide-react';
-import HomeSectionLink from './HomeSectionLink';
 import Footer from './Footer';
+import NavigationMenu, { NavigationCallbacks } from './NavigationMenu';
 
 interface Paris9PageProps {
   onBack: () => void;
@@ -28,7 +28,19 @@ const Paris9Page: React.FC<Paris9PageProps> = ({
   onQuoteRequest,
   onPhotoboothDetails,
   onAIAnimations,
-  onSEOPage, arrondissementLinks }) => {
+  onSEOPage,
+  arrondissementLinks,
+}) => {
+  const navigationCallbacks = useMemo<NavigationCallbacks>(
+    () => ({
+      '/': onBack,
+      ...(onPhotoboothDetails ? { '/location-photobooth-paris': onPhotoboothDetails } : {}),
+      ...(onAIAnimations ? { '/animations-photobooth-ia': onAIAnimations } : {}),
+      ...(onQuoteRequest ? { '/devis-photobooth-gratuit': onQuoteRequest } : {}),
+    }),
+    [onAIAnimations, onBack, onPhotoboothDetails, onQuoteRequest],
+  );
+
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -42,34 +54,7 @@ const Paris9Page: React.FC<Paris9PageProps> = ({
               <span className="text-2xl font-bold text-black">BoostPix</span>
             </div>
 
-            <nav className="hidden lg:flex items-center space-x-8">
-              <button
-                onClick={onBack}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Accueil
-              </button>
-              <button
-                onClick={onPhotoboothDetails}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Photobooth sur mesure
-              </button>
-              <HomeSectionLink label="Événements Privés" targetId="mariages" onBack={onBack} />
-              <button
-                onClick={onAIAnimations}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Animations IA
-              </button>
-              <HomeSectionLink label="Galerie" targetId="galerie" onBack={onBack} />
-              <button
-                onClick={onQuoteRequest}
-                className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
-              >
-                Devis Gratuit
-              </button>
-            </nav>
+            <NavigationMenu className="hidden lg:flex" onNavigate={navigationCallbacks} />
 
             <button
               onClick={onBack}

--- a/src/components/PhotoboothDetailsPage.tsx
+++ b/src/components/PhotoboothDetailsPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   ArrowLeft,
   Camera,
@@ -13,8 +13,8 @@ import {
   Play,
   ArrowRight
 } from 'lucide-react';
-import HomeSectionLink from './HomeSectionLink';
 import Footer from './Footer';
+import NavigationMenu, { NavigationCallbacks } from './NavigationMenu';
 
 interface PhotoboothDetailsPageProps {
   onBack: () => void;
@@ -23,7 +23,21 @@ interface PhotoboothDetailsPageProps {
   arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
-const PhotoboothDetailsPage: React.FC<PhotoboothDetailsPageProps> = ({ onBack, onAIAnimations, onQuoteRequest, arrondissementLinks}) => {
+const PhotoboothDetailsPage: React.FC<PhotoboothDetailsPageProps> = ({
+  onBack,
+  onAIAnimations,
+  onQuoteRequest,
+  arrondissementLinks,
+}) => {
+  const navigationCallbacks = useMemo<NavigationCallbacks>(
+    () => ({
+      '/': onBack,
+      ...(onAIAnimations ? { '/animations-photobooth-ia': onAIAnimations } : {}),
+      ...(onQuoteRequest ? { '/devis-photobooth-gratuit': onQuoteRequest } : {}),
+    }),
+    [onAIAnimations, onBack, onQuoteRequest],
+  );
+
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -37,31 +51,7 @@ const PhotoboothDetailsPage: React.FC<PhotoboothDetailsPageProps> = ({ onBack, o
               <span className="text-2xl font-bold text-black">BoostPix</span>
             </div>
 
-            <nav className="hidden lg:flex items-center space-x-8">
-              <button 
-                onClick={onBack}
-               className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-               Accueil
-              </button>
-              <span className="text-yellow-500 font-medium cursor-default">
-                Photobooth sur mesure
-              </span>
-              <HomeSectionLink label="Événements Privés" targetId="mariages" onBack={onBack} />
-              <button 
-                onClick={onAIAnimations}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Animations IA
-              </button>
-              <HomeSectionLink label="Galerie" targetId="galerie" onBack={onBack} />
-              <button 
-                onClick={onQuoteRequest}
-                className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
-              >
-                Devis Gratuit
-              </button>
-            </nav>
+            <NavigationMenu className="hidden lg:flex" onNavigate={navigationCallbacks} />
 
             <button 
               onClick={onBack}

--- a/src/components/PhotographerAIPage.tsx
+++ b/src/components/PhotographerAIPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   ArrowLeft,
   Camera,
@@ -17,8 +17,8 @@ import {
   Globe,
   Flame
 } from 'lucide-react';
-import HomeSectionLink from './HomeSectionLink';
 import Footer from './Footer';
+import NavigationMenu, { NavigationCallbacks } from './NavigationMenu';
 
 interface PhotographerAIPageProps {
   onBack: () => void;
@@ -29,7 +29,24 @@ interface PhotographerAIPageProps {
   arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
-const PhotographerAIPage: React.FC<PhotographerAIPageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, onSEOPage, arrondissementLinks }) => {
+const PhotographerAIPage: React.FC<PhotographerAIPageProps> = ({
+  onBack,
+  onQuoteRequest,
+  onPhotoboothDetails,
+  onAIAnimations,
+  onSEOPage,
+  arrondissementLinks,
+}) => {
+  const navigationCallbacks = useMemo<NavigationCallbacks>(
+    () => ({
+      '/': onBack,
+      ...(onPhotoboothDetails ? { '/location-photobooth-paris': onPhotoboothDetails } : {}),
+      ...(onAIAnimations ? { '/animations-photobooth-ia': onAIAnimations } : {}),
+      ...(onQuoteRequest ? { '/devis-photobooth-gratuit': onQuoteRequest } : {}),
+    }),
+    [onAIAnimations, onBack, onPhotoboothDetails, onQuoteRequest],
+  );
+
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -43,34 +60,7 @@ const PhotographerAIPage: React.FC<PhotographerAIPageProps> = ({ onBack, onQuote
               <span className="text-2xl font-bold text-black">BoostPix</span>
             </div>
 
-            <nav className="hidden lg:flex items-center space-x-8">
-              <button 
-                onClick={onBack}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Accueil
-              </button>
-              <button 
-                onClick={onPhotoboothDetails}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Photobooth sur mesure
-              </button>
-              <HomeSectionLink label="Événements Privés" targetId="mariages" onBack={onBack} />
-              <button 
-                onClick={onAIAnimations}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Animations IA
-              </button>
-              <HomeSectionLink label="Galerie" targetId="galerie" onBack={onBack} />
-              <button 
-                onClick={onQuoteRequest}
-                className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
-              >
-                Devis Gratuit
-              </button>
-            </nav>
+            <NavigationMenu className="hidden lg:flex" onNavigate={navigationCallbacks} />
 
             <button 
               onClick={onBack}

--- a/src/components/PrivateEventsPage.tsx
+++ b/src/components/PrivateEventsPage.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Camera, Heart, Sparkles, MapPin, Check } from 'lucide-react';
 import Footer from './Footer';
+import NavigationMenu, { NavigationCallbacks } from './NavigationMenu';
 
 interface PrivateEventsPageProps {
   onBack: () => void;
@@ -19,6 +20,16 @@ const PrivateEventsPage: React.FC<PrivateEventsPageProps> = ({
   onSEOPage,
   arrondissementLinks,
 }) => {
+  const navigationCallbacks = useMemo<NavigationCallbacks>(
+    () => ({
+      ...(onBack ? { '/': onBack } : {}),
+      ...(onPhotoboothDetails ? { '/location-photobooth-paris': onPhotoboothDetails } : {}),
+      ...(onAIAnimations ? { '/animations-photobooth-ia': onAIAnimations } : {}),
+      ...(onQuoteRequest ? { '/devis-photobooth-gratuit': onQuoteRequest } : {}),
+    }),
+    [onAIAnimations, onBack, onPhotoboothDetails, onQuoteRequest],
+  );
+
   return (
     <div className="min-h-screen bg-white">
       <header className="fixed top-0 left-0 right-0 bg-white/95 backdrop-blur-sm z-50 border-b border-gray-100">
@@ -31,24 +42,7 @@ const PrivateEventsPage: React.FC<PrivateEventsPageProps> = ({
               <span className="text-2xl font-bold text-black">BoostPix</span>
             </div>
 
-            <nav className="hidden lg:flex items-center space-x-8">
-              <button onClick={onBack} className="text-gray-700 hover:text-yellow-500 transition-colors font-medium">
-                Accueil
-              </button>
-              <button onClick={onPhotoboothDetails} className="text-gray-700 hover:text-yellow-500 transition-colors font-medium">
-                Photobooth sur mesure
-              </button>
-              <span className="text-yellow-500 font-medium cursor-default">Événements Privés</span>
-              <button onClick={onAIAnimations} className="text-gray-700 hover:text-yellow-500 transition-colors font-medium">
-                Animations IA
-              </button>
-              <button
-                onClick={onQuoteRequest}
-                className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
-              >
-                Devis Gratuit
-              </button>
-            </nav>
+            <NavigationMenu className="hidden lg:flex" onNavigate={navigationCallbacks} />
           </div>
         </div>
       </header>

--- a/src/components/QuotePage.tsx
+++ b/src/components/QuotePage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   ArrowLeft,
   MapPin,
@@ -11,14 +11,14 @@ import {
   Check,
   ChevronRight
 } from 'lucide-react';
-import HomeSectionLink from './HomeSectionLink';
 import Footer from './Footer';
+import NavigationMenu, { NavigationCallbacks } from './NavigationMenu';
 
 interface QuotePageProps {
   onBack: () => void;
   onSEOPage?: () => void;
   arrondissementLinks: { label: string; onClick: () => void }[];
-  }
+}
 
 const QuotePage: React.FC<QuotePageProps> = ({ onBack, onSEOPage, arrondissementLinks }) => {
   const [currentStep, setCurrentStep] = useState(1);
@@ -135,6 +135,11 @@ const QuotePage: React.FC<QuotePageProps> = ({ onBack, onSEOPage, arrondissement
     }
   };
 
+  const navigationCallbacks = useMemo<NavigationCallbacks>(
+    () => ({ '/': onBack }),
+    [onBack],
+  );
+
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
@@ -148,31 +153,7 @@ const QuotePage: React.FC<QuotePageProps> = ({ onBack, onSEOPage, arrondissement
               <span className="text-2xl font-bold text-black">BoostPix</span>
             </div>
 
-            <nav className="hidden lg:flex items-center space-x-8">
-              <button 
-                onClick={onBack}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Accueil
-              </button>
-              <button 
-                onClick={onBack}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Photobooth sur mesure
-              </button>
-              <HomeSectionLink label="Événements Privés" targetId="mariages" onBack={onBack} />
-              <button 
-                onClick={onBack}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Animations IA
-              </button>
-              <HomeSectionLink label="Galerie" targetId="galerie" onBack={onBack} />
-              <button className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold">
-                Devis Gratuit
-              </button>
-            </nav>
+            <NavigationMenu className="hidden lg:flex" onNavigate={navigationCallbacks} />
 
             <button 
               onClick={onBack}

--- a/src/components/SEOPage.tsx
+++ b/src/components/SEOPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   ArrowLeft,
   Camera,
@@ -14,8 +14,8 @@ import {
   Share2,
   Eye
 } from 'lucide-react';
-import HomeSectionLink from './HomeSectionLink';
 import Footer from './Footer';
+import NavigationMenu, { NavigationCallbacks } from './NavigationMenu';
 
 interface SEOPageProps {
   onBack: () => void;
@@ -25,7 +25,23 @@ interface SEOPageProps {
   arrondissementLinks: { label: string; onClick: () => void }[];
 }
 
-const SEOPage: React.FC<SEOPageProps> = ({ onBack, onQuoteRequest, onPhotoboothDetails, onAIAnimations, arrondissementLinks}) => {
+const SEOPage: React.FC<SEOPageProps> = ({
+  onBack,
+  onQuoteRequest,
+  onPhotoboothDetails,
+  onAIAnimations,
+  arrondissementLinks,
+}) => {
+  const navigationCallbacks = useMemo<NavigationCallbacks>(
+    () => ({
+      '/': onBack,
+      ...(onPhotoboothDetails ? { '/location-photobooth-paris': onPhotoboothDetails } : {}),
+      ...(onAIAnimations ? { '/animations-photobooth-ia': onAIAnimations } : {}),
+      ...(onQuoteRequest ? { '/devis-photobooth-gratuit': onQuoteRequest } : {}),
+    }),
+    [onAIAnimations, onBack, onPhotoboothDetails, onQuoteRequest],
+  );
+
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -39,34 +55,7 @@ const SEOPage: React.FC<SEOPageProps> = ({ onBack, onQuoteRequest, onPhotoboothD
               <span className="text-2xl font-bold text-black">BoostPix</span>
             </div>
 
-            <nav className="hidden lg:flex items-center space-x-8">
-              <button 
-                onClick={onBack}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Accueil
-              </button>
-              <button 
-                onClick={onPhotoboothDetails}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Photobooth sur mesure
-              </button>
-              <HomeSectionLink label="Événements Privés" targetId="mariages" onBack={onBack} />
-              <button 
-                onClick={onAIAnimations}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Animations IA
-              </button>
-              <HomeSectionLink label="Galerie" targetId="galerie" onBack={onBack} />
-              <button 
-                onClick={onQuoteRequest}
-                className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
-              >
-                Devis Gratuit
-              </button>
-            </nav>
+            <NavigationMenu className="hidden lg:flex" onNavigate={navigationCallbacks} />
 
             <button 
               onClick={onBack}

--- a/src/components/ServicesPage.tsx
+++ b/src/components/ServicesPage.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Camera, Users, Sparkles, Heart, ArrowRight, Check } from 'lucide-react';
 import Footer from './Footer';
+import NavigationMenu, { NavigationCallbacks } from './NavigationMenu';
 
 interface ServicesPageProps {
   onBack: () => void;
@@ -21,6 +22,17 @@ const ServicesPage: React.FC<ServicesPageProps> = ({
   onSEOPage,
   arrondissementLinks,
 }) => {
+  const navigationCallbacks = useMemo<NavigationCallbacks>(
+    () => ({
+      ...(onBack ? { '/': onBack } : {}),
+      ...(onPhotoboothDetails ? { '/location-photobooth-paris': onPhotoboothDetails } : {}),
+      ...(onPrivateEvents ? { '/photobooth-evenement-paris': onPrivateEvents } : {}),
+      ...(onAIAnimations ? { '/animations-photobooth-ia': onAIAnimations } : {}),
+      ...(onQuoteRequest ? { '/devis-photobooth-gratuit': onQuoteRequest } : {}),
+    }),
+    [onAIAnimations, onBack, onPhotoboothDetails, onPrivateEvents, onQuoteRequest],
+  );
+
   return (
     <div className="min-h-screen bg-white">
       <header className="fixed top-0 left-0 right-0 bg-white/95 backdrop-blur-sm z-50 border-b border-gray-100">
@@ -33,30 +45,7 @@ const ServicesPage: React.FC<ServicesPageProps> = ({
               <span className="text-2xl font-bold text-black">BoostPix</span>
             </div>
 
-            <nav className="hidden lg:flex items-center space-x-8">
-              <button onClick={onBack} className="text-gray-700 hover:text-yellow-500 transition-colors font-medium">
-                Accueil
-              </button>
-              <span className="text-yellow-500 font-medium cursor-default">Services</span>
-              <button
-                onClick={onPhotoboothDetails}
-                className="text-gray-700 hover:text-yellow-500 transition-colors font-medium"
-              >
-                Photobooth sur mesure
-              </button>
-              <button onClick={onPrivateEvents} className="text-gray-700 hover:text-yellow-500 transition-colors font-medium">
-                Événements Privés
-              </button>
-              <button onClick={onAIAnimations} className="text-gray-700 hover:text-yellow-500 transition-colors font-medium">
-                Animations IA
-              </button>
-              <button
-                onClick={onQuoteRequest}
-                className="bg-yellow-400 text-black px-6 py-3 rounded-full hover:bg-yellow-500 transition-colors font-semibold"
-              >
-                Devis Gratuit
-              </button>
-            </nav>
+            <NavigationMenu className="hidden lg:flex" onNavigate={navigationCallbacks} />
           </div>
         </div>
       </header>


### PR DESCRIPTION
## Summary
- add a reusable NavigationMenu component that uses the router to render the shared navigation list with active styling
- replace the duplicated desktop and mobile nav button groups across the home page and other sections with the new component, wiring page-specific callbacks where needed
- update arrondissement layout and detail pages to use the shared menu while keeping custom back/quote handlers

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc5003e7b88331a78b37b5b4840f4c